### PR TITLE
Added `torch.no_grad()` scope in `PytorchEstimator.predict_proba`

### DIFF
--- a/dlordinal/estimator/pytorch_estimator.py
+++ b/dlordinal/estimator/pytorch_estimator.py
@@ -23,7 +23,7 @@ class PytorchEstimator(BaseEstimator):
         A Pytorch device.
     max_iter : int
         The maximum number of iterations.
-    \**kwargs : dict
+    **kwargs : dict
         Additional keyword arguments.
     """
 

--- a/dlordinal/losses/beta_loss.py
+++ b/dlordinal/losses/beta_loss.py
@@ -122,7 +122,7 @@ class BetaCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     Parameters
     ----------
-    num_classes : int, default=5
+    num_classes : int
         Number of classes.
     params_set : str, default='standard'
         The set of parameters to use for the beta distribution (chosen from the
@@ -162,7 +162,7 @@ class BetaCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     def __init__(
         self,
-        num_classes: int = 5,
+        num_classes: int,
         params_set: str = "standard",
         eta: float = 1.0,
         weight: Optional[Tensor] = None,

--- a/dlordinal/losses/binomial_loss.py
+++ b/dlordinal/losses/binomial_loss.py
@@ -12,7 +12,7 @@ class BinomialCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     Parameters
     ----------
-    num_classes : int, default=5
+    num_classes : int
         Number of classes.
     eta : float, default=1.0
         Parameter that controls the influence of the regularisation.
@@ -49,7 +49,7 @@ class BinomialCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     def __init__(
         self,
-        num_classes: int = 5,
+        num_classes: int,
         eta: float = 1.0,
         weight: Optional[Tensor] = None,
         size_average=None,

--- a/dlordinal/losses/exponential_loss.py
+++ b/dlordinal/losses/exponential_loss.py
@@ -12,7 +12,7 @@ class ExponentialRegularisedCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     Parameters
     ----------
-    num_classes : int, default=5
+    num_classes : int
         Number of classes.
     eta : float, default=1.0
         Parameter that controls the influence of the regularisation.
@@ -52,7 +52,7 @@ class ExponentialRegularisedCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     def __init__(
         self,
-        num_classes: int = 5,
+        num_classes: int,
         eta: float = 1.0,
         p: float = 1,
         weight: Optional[Tensor] = None,

--- a/dlordinal/losses/poisson_loss.py
+++ b/dlordinal/losses/poisson_loss.py
@@ -12,7 +12,7 @@ class PoissonCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     Parameters
     ----------
-    num_classes : int, default=5
+    num_classes : int
         Number of classes.
     eta : float, default=1.0
         Parameter that controls the influence of the regularisation.
@@ -49,7 +49,7 @@ class PoissonCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     def __init__(
         self,
-        num_classes: int = 5,
+        num_classes: int,
         eta: float = 1.0,
         weight: Optional[Tensor] = None,
         size_average=None,

--- a/dlordinal/losses/tests/test_beta_loss.py
+++ b/dlordinal/losses/tests/test_beta_loss.py
@@ -5,7 +5,7 @@ from ..beta_loss import BetaCrossEntropyLoss
 
 
 def test_beta_loss_creation():
-    loss = BetaCrossEntropyLoss()
+    loss = BetaCrossEntropyLoss(num_classes=5)
     assert isinstance(loss, BetaCrossEntropyLoss)
 
 

--- a/dlordinal/losses/tests/test_binomial_loss.py
+++ b/dlordinal/losses/tests/test_binomial_loss.py
@@ -5,7 +5,7 @@ from ..binomial_loss import BinomialCrossEntropyLoss
 
 
 def test_binomial_loss_creation():
-    loss = BinomialCrossEntropyLoss()
+    loss = BinomialCrossEntropyLoss(num_classes=5)
     assert isinstance(loss, BinomialCrossEntropyLoss)
 
 

--- a/dlordinal/losses/tests/test_exponential_loss.py
+++ b/dlordinal/losses/tests/test_exponential_loss.py
@@ -5,7 +5,7 @@ from ..exponential_loss import ExponentialRegularisedCrossEntropyLoss
 
 
 def test_exponential_loss_creation():
-    loss = ExponentialRegularisedCrossEntropyLoss()
+    loss = ExponentialRegularisedCrossEntropyLoss(num_classes=5)
     assert isinstance(loss, ExponentialRegularisedCrossEntropyLoss)
 
 

--- a/dlordinal/losses/tests/test_poisson_loss.py
+++ b/dlordinal/losses/tests/test_poisson_loss.py
@@ -5,7 +5,7 @@ from ..poisson_loss import PoissonCrossEntropyLoss
 
 
 def test_poisson_loss_creation():
-    loss = PoissonCrossEntropyLoss()
+    loss = PoissonCrossEntropyLoss(num_classes=5)
     assert isinstance(loss, PoissonCrossEntropyLoss)
 
 

--- a/dlordinal/losses/tests/test_triangular_loss.py
+++ b/dlordinal/losses/tests/test_triangular_loss.py
@@ -5,7 +5,7 @@ from ..triangular_loss import TriangularCrossEntropyLoss
 
 
 def test_triangular_loss_creation():
-    loss = TriangularCrossEntropyLoss()
+    loss = TriangularCrossEntropyLoss(num_classes=5)
     assert isinstance(loss, TriangularCrossEntropyLoss)
 
 

--- a/dlordinal/losses/triangular_loss.py
+++ b/dlordinal/losses/triangular_loss.py
@@ -12,7 +12,7 @@ class TriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     Parameters
     ----------
-    num_classes : int, default=5
+    num_classes : int
         Number of classes.
     alpha2 : float, default=0.05
         Parameter that controls the influence of the regularisation.
@@ -51,7 +51,7 @@ class TriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
 
     def __init__(
         self,
-        num_classes: int = 5,
+        num_classes: int,
         alpha2: float = 0.05,
         eta: float = 1.0,
         weight: Optional[Tensor] = None,


### PR DESCRIPTION
Added `torch.no_grad()` scope in `PytorchEstimator.predict_proba` to avoid the need of using `.detach()` when converting predictions to numpy.