### PR TITLE
Update the pretrained parameter to weights in the tutorials

### DIFF
--- a/tutorials/estimator_tutorial.ipynb
+++ b/tutorials/estimator_tutorial.ipynb
@@ -142,7 +142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models.resnet18(pretrained=True)\n",
+    "model = models.resnet18(weights='IMAGENET1K_V1')\n",
     "model.fc = nn.Linear(model.fc.in_features, num_classes)\n",
     "model = model.to(device)\n",
     "\n",
@@ -282,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/tutorials/losses_tutorial.ipynb
+++ b/tutorials/losses_tutorial.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models.resnet18(pretrained=True)\n",
+    "model = models.resnet18(weights='IMAGENET1K_V1')\n",
     "model.fc = nn.Linear(model.fc.in_features, num_classes)\n",
     "model = model.to(device)\n",
     "\n",

--- a/tutorials/stick_breaking_tutorial.ipynb
+++ b/tutorials/stick_breaking_tutorial.ipynb
@@ -171,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models.resnet18(pretrained=True)\n",
+    "model = models.resnet18(weights='IMAGENET1K_V1')\n",
     "model.fc = StickBreakingLayer(model.fc.in_features, num_classes)\n",
     "model = model.to(device)\n",
     "\n",


### PR DESCRIPTION
Updated the ``pretrained=True`` parameter to ``weights='IMAGENET1K_V1'`` in the tutorials to avoid warnings in current versions of ``torch`` and ``torchvision``. Associated with the issue https://github.com/ayrna/dlordinal/issues/51