### PR TITLE
Elimination of `label_smoothing` parameter

### DIFF
--- a/dlordinal/losses/beta_loss.py
+++ b/dlordinal/losses/beta_loss.py
@@ -45,9 +45,6 @@ class BetaCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -60,7 +57,6 @@ class BetaCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         cls_probs = torch.tensor(get_beta_soft_labels(num_classes, params_set)).float()
@@ -73,5 +69,5 @@ class BetaCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )

--- a/dlordinal/losses/binomial_loss.py
+++ b/dlordinal/losses/binomial_loss.py
@@ -42,9 +42,6 @@ class BinomialCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -56,7 +53,6 @@ class BinomialCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         cls_probs = torch.tensor(get_binomial_soft_labels(num_classes)).float()
@@ -69,5 +65,5 @@ class BinomialCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )

--- a/dlordinal/losses/exponential_loss.py
+++ b/dlordinal/losses/exponential_loss.py
@@ -45,9 +45,6 @@ class ExponentialRegularisedCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -60,7 +57,6 @@ class ExponentialRegularisedCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         cls_probs = torch.tensor(get_exponential_soft_labels(num_classes, p)).float()
@@ -73,5 +69,5 @@ class ExponentialRegularisedCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )

--- a/dlordinal/losses/general_triangular_loss.py
+++ b/dlordinal/losses/general_triangular_loss.py
@@ -45,9 +45,6 @@ class GeneralTriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -60,7 +57,6 @@ class GeneralTriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         r = get_general_triangular_soft_labels(num_classes, alphas, verbose=0)
@@ -74,5 +70,5 @@ class GeneralTriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )

--- a/dlordinal/losses/poisson_loss.py
+++ b/dlordinal/losses/poisson_loss.py
@@ -42,9 +42,6 @@ class PoissonCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -56,7 +53,6 @@ class PoissonCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         cls_probs = torch.tensor(get_poisson_soft_labels(num_classes)).float()
@@ -69,5 +65,5 @@ class PoissonCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )

--- a/dlordinal/losses/triangular_loss.py
+++ b/dlordinal/losses/triangular_loss.py
@@ -44,9 +44,6 @@ class TriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         :attr:`reduce` are in the process of being deprecated, and in the meantime,
         specifying either of those two args will override :attr:`reduction`.
         Default: ``'mean'``
-    label_smoothing : float, default=0.0
-        Controls the amount of label smoothing for the loss. Zero means no smoothing.
-        Default: ``0.0``
     """
 
     def __init__(
@@ -59,7 +56,6 @@ class TriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
         ignore_index: int = -100,
         reduce=None,
         reduction: str = "mean",
-        label_smoothing: float = 0.0,
     ):
         # Precompute class probabilities for each label
         cls_probs = torch.tensor(get_triangular_soft_labels(num_classes, alpha2))
@@ -71,5 +67,5 @@ class TriangularCrossEntropyLoss(CustomTargetsCrossEntropyLoss):
             ignore_index=ignore_index,
             reduce=reduce,
             reduction=reduction,
-            label_smoothing=label_smoothing,
+            label_smoothing=0.0,
         )


### PR DESCRIPTION
The `label_smoothing` parameter of the soft labelling loss functions has been removed. Associated with the issue https://github.com/ayrna/dlordinal/issues/58