### PR TITLE
[MNT] Updated github actions workflows

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,38 +11,13 @@ on:
   pull_request:
     branches:
       - main
-      - development
     paths:
       - "tutorials/**"
       - "dlordinal/**"
       - ".github/workflows/**"
 
 jobs:
-  tests:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.8
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install codecov
-        pip install pytest-cov
-        pip install .
-
-    - name: Run tests
-      run: |
-        pytest -v
-
-  codecov:
-    needs: tests
+  tests-codecov:
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@
 
 | Overview  |                                                                                                                                          |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------|
-| **CI/CD** | [![!codecov](https://img.shields.io/codecov/c/github/ayrna/dlordinal?label=codecov&logo=codecov)](https://codecov.io/gh/ayrna/dlordinal) [![!docs](https://readthedocs.org/projects/dlordinal/badge/?version=latest&style=flat)](https://dlordinal.readthedocs.io/en/latest/)  [![!python](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10-blue)](https://www.python.org/) |
+| **CI/CD** | [![!codecov](https://img.shields.io/codecov/c/github/ayrna/dlordinal?label=codecov&logo=codecov)](https://codecov.io/gh/ayrna/dlordinal) [![!docs](https://readthedocs.org/projects/dlordinal/badge/?version=latest&style=flat)](https://dlordinal.readthedocs.io/en/latest/)  [![!python](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12-blue)](https://www.python.org/) |
 | **Code**  | [![![pypi]](https://img.shields.io/pypi/v/dlordinal)](https://pypi.org/project/dlordinal/2.0.0/) [![![binder]](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ayrna/dlordinal/main?filepath=tutorials) [![!black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Linter: Ruff](https://img.shields.io/badge/Linter-Ruff-brightgreen?style=flat-square)](https://github.com/charliermarsh/ruff)                     |
 
 
 ## Table of Contents
-- [⚙️ Installation](#%EF%B8%8F-installation)
-- [📖 Documentation](#-documentation)
-- [Collaborating](#collaborating)
+- [Deep learning utilities library](#deep-learning-utilities-library)
+  - [Table of Contents](#table-of-contents)
+  - [⚙️ Installation](#️-installation)
+  - [📖 Documentation](#-documentation)
+  - [Collaborating](#collaborating)
     - [Guidelines for code contributions](#guidelines-for-code-contributions)
 
 ## ⚙️ Installation


### PR DESCRIPTION
- Run Tests workflow has been simplified by joining tests and codecov executions.
- Python version used to run the tutorial notebooks has been changed to 3.8 to be consistent with tests' version.