### PR TITLE
[BUG] AMAE and MAE correction

### DIFF
--- a/dlordinal/metrics/metrics.py
+++ b/dlordinal/metrics/metrics.py
@@ -205,10 +205,14 @@ def amae(y_true: np.ndarray, y_pred: np.ndarray):
     n_class = cm.shape[0]
     costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
     costs = np.abs(costs - np.transpose(costs))
+    errors = costs * cm
+
+    # Remove rows with all zeros in the confusion matrix
     non_zero_cm_rows = ~np.all(cm == 0, axis=1)
-    cm_ = cm[non_zero_cm_rows]
-    errors = costs * cm_
-    per_class_maes = np.sum(errors, axis=1) / np.sum(cm_, axis=1).astype("double")
+    errors = errors[non_zero_cm_rows]
+    cm = cm[non_zero_cm_rows]
+
+    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
     return np.mean(per_class_maes)
 
 
@@ -249,10 +253,14 @@ def mmae(y_true: np.ndarray, y_pred: np.ndarray):
     n_class = cm.shape[0]
     costs = np.reshape(np.tile(range(n_class), n_class), (n_class, n_class))
     costs = np.abs(costs - np.transpose(costs))
+    errors = costs * cm
+
+    # Remove rows with all zeros in the confusion matrix
     non_zero_cm_rows = ~np.all(cm == 0, axis=1)
-    cm_ = cm[non_zero_cm_rows]
-    errors = costs * cm_
-    per_class_maes = np.sum(errors, axis=1) / np.sum(cm_, axis=1).astype("double")
+    errors = errors[non_zero_cm_rows]
+    cm = cm[non_zero_cm_rows]
+
+    per_class_maes = np.sum(errors, axis=1) / np.sum(cm, axis=1).astype("double")
     return per_class_maes.max()
 
 

--- a/dlordinal/metrics/tests/test_metrics.py
+++ b/dlordinal/metrics/tests/test_metrics.py
@@ -98,6 +98,12 @@ def test_amae():
     expected_result = 0.5
     assert result == pytest.approx(expected_result, rel=1e-6)
 
+    y_true = np.array([0, 1, 2, 3, 3])
+    y_pred = np.array([0, 1, 2, 3, 4])
+    result = amae(y_true, y_pred)
+    expected_result = 0.125
+    assert result == pytest.approx(expected_result, rel=1e-6)
+
 
 def test_mmae():
     y_true = np.array([0, 0, 1, 1])
@@ -127,6 +133,12 @@ def test_mmae():
     # Test using one-hot and probabilities
     y_true = np.array([[1, 0], [1, 0], [0, 1], [0, 1]])
     y_pred = np.array([[1, 0], [0, 1], [1, 0], [0, 1]])
+    result = mmae(y_true, y_pred)
+    expected_result = 0.5
+    assert result == pytest.approx(expected_result, rel=1e-6)
+
+    y_true = np.array([0, 1, 2, 3, 3])
+    y_pred = np.array([0, 1, 2, 3, 4])
     result = mmae(y_true, y_pred)
     expected_result = 0.5
     assert result == pytest.approx(expected_result, rel=1e-6)


### PR DESCRIPTION
AMAE and MAE metrics have been corrected due to a bug detected in issue #94. An issue with the shapes of the confusion matrix and cost matrix was identified when a class is missing in the `y_true` labels.