### PR TITLE
Correction of compute_per_class_mse documentation

### DIFF
--- a/dlordinal/losses/mceloss.py
+++ b/dlordinal/losses/mceloss.py
@@ -61,7 +61,7 @@ class MCELoss(torch.nn.modules.loss._WeightedLoss):
         target : torch.Tensor
             Ground truth labels
 
-        Returns:
+        Returns
         --------
         mses : torch.Tensor
             MSE values


### PR DESCRIPTION
The compute_per_class_mse documentation has been corrected. The related issue is #97 