### PR TITLE
[ENH] Added support for logits or probabilities to the `WKLoss`

### DIFF
--- a/dlordinal/losses/mcewkloss.py
+++ b/dlordinal/losses/mcewkloss.py
@@ -30,6 +30,9 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
         ``'sum'``. ``'none'``: no reduction will be applied, ``'mean'``: the sum of
         the output will be divided by the number of elements in the output,
         ``'sum'``: the output will be summed.
+    use_logits : bool, default=False
+        If True, the input y_pred will be treated as logits.
+        If False, the input y_pred will be treated as probabilities.
     """
 
     def __init__(
@@ -39,6 +42,7 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
         wk_penalization_type: str = "quadratic",
         weight: Optional[Tensor] = None,
         reduction: str = "mean",
+        use_logits=False,
     ) -> None:
         super().__init__(
             weight=weight, size_average=None, reduce=None, reduction=reduction
@@ -63,12 +67,15 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
                 + " Please use 'mean', 'sum' or 'none'"
             )
 
+        self.use_logits = use_logits
+
         self.wk = WKLoss(
             self.num_classes,
             penalization_type=self.wk_penalization_type,
             weight=weight,
+            use_logits=self.use_logits,
         )
-        self.mce = MCELoss(self.num_classes, weight=weight)
+        self.mce = MCELoss(self.num_classes, weight=weight, use_logits=self.use_logits)
 
     def forward(self, y_true: torch.Tensor, y_pred: torch.Tensor):
         """

--- a/dlordinal/losses/tests/test_mcewkloss.py
+++ b/dlordinal/losses/tests/test_mcewkloss.py
@@ -4,17 +4,29 @@ import torch
 from dlordinal.losses import MCEAndWKLoss, MCELoss, WKLoss
 
 
-def test_mcewkloss_creation():
-    loss = MCEAndWKLoss(num_classes=6)
+@pytest.fixture
+def device():
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def test_mcewkloss_creation(device):
+    loss = MCEAndWKLoss(num_classes=6).to(device)
+    loss_logits = MCEAndWKLoss(num_classes=6, use_logits=True).to(device)
     assert isinstance(loss, MCEAndWKLoss)
+    assert isinstance(loss_logits, MCEAndWKLoss)
 
 
-def test_mcewkloss_basic():
+def test_mcewkloss_basic(device):
     num_classes = 6
     C = 0.5
     penalization_type = "quadratic"
 
-    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type)
+    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type).to(
+        device
+    )
+    loss_logits = MCEAndWKLoss(
+        num_classes, C=C, wk_penalization_type=penalization_type, use_logits=True
+    ).to(device)
 
     input_data = torch.tensor(
         [
@@ -22,26 +34,35 @@ def test_mcewkloss_basic():
             [-2.4079, -2.1725, -2.1459, -3.3318, -3.9624, -4.4700],
             [-2.4079, -1.7924, -2.0101, -4.1030, -3.3445, -4.4812],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([2, 2, 1])
+    target = torch.tensor([2, 2, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
+    assert isinstance(output_logits, torch.Tensor)
 
     # Verifies that the loss is greater than zero
     assert output.item() > 0
+    assert output_logits.item() > 0
+    assert output.item() == pytest.approx(output_logits.item())
 
 
-def test_mcewkloss_exactvalue():
+def test_mcewkloss_exactvalue(device):
     num_classes = 6
     C = 0.5
     penalization_type = "quadratic"
 
-    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type)
+    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type).to(
+        device
+    )
+    loss_logits = MCEAndWKLoss(
+        num_classes, C=C, wk_penalization_type=penalization_type, use_logits=True
+    ).to(device)
 
     input_data = torch.tensor(
         [
@@ -56,29 +77,46 @@ def test_mcewkloss_exactvalue():
             [-0.3806, -2.0569, -0.8110, -2.1876, -0.0553, 0.0071],
             [1.0932, 1.0941, 0.5114, -0.3906, 0.3693, 1.7794],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([0, 1, 2, 3, 4, 5, 4, 3, 2, 1])
+    target = torch.tensor([0, 1, 2, 3, 4, 5, 4, 3, 2, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
-    assert output.item() == pytest.approx(0.5625, rel=1e-3)
+    assert output.item() == pytest.approx(0.5404, rel=1e-3)
+    assert output_logits.item() == pytest.approx(0.5404, rel=1e-3)
 
 
-def test_mcewkloss_weights():
+def test_mcewkloss_weights(device):
     num_classes = 6
     C = 0.5
     penalization_type = "quadratic"
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type)
+    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type).to(
+        device
+    )
     loss_weighted = MCEAndWKLoss(
         num_classes, C=C, wk_penalization_type=penalization_type, weight=weight
-    )
+    ).to(device)
+    loss_logits = MCEAndWKLoss(
+        num_classes,
+        C=C,
+        wk_penalization_type=penalization_type,
+        use_logits=True,
+    ).to(device)
+    loss_logits_weighted = MCEAndWKLoss(
+        num_classes,
+        C=C,
+        wk_penalization_type=penalization_type,
+        weight=weight,
+        use_logits=True,
+    ).to(device)
 
     input_data = torch.tensor(
         [
@@ -89,36 +127,56 @@ def test_mcewkloss_weights():
     )
 
     # Error in classes 1 and 3 (pattern from class 1 classified as 3)
-    target = torch.tensor([3, 3, 1])
+    target = torch.tensor([3, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
-    output_weighted = loss_weighted(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_weighted = loss_weighted(
+        torch.nn.functional.softmax(input_data, dim=1), target
+    )
+    output_logits = loss_logits(input_data, target)
+    output_logits_weighted = loss_logits_weighted(input_data, target)
 
     # The error should be lower when using the weighted version as the weight
     # of classes 1 and 3 is less than 1
     assert output.item() > output_weighted.item()
+    assert output_logits.item() > output_logits_weighted.item()
 
     # Error in classes 1 and 5 (pattern from class 1 classified as 5)
-    target = torch.tensor([5, 3, 1])
+    target = torch.tensor([5, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
-    output_weighted = loss_weighted(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_weighted = loss_weighted(
+        torch.nn.functional.softmax(input_data, dim=1), target
+    )
+    output_logits = loss_logits(input_data, target)
+    output_logits_weighted = loss_logits_weighted(input_data, target)
 
     # The error should be higher when using the weighted version as the weight
     # of class 5 is way higher than 1
     assert output.item() < output_weighted.item()
+    assert output_logits.item() < output_logits_weighted.item()
 
 
-def test_mcewkloss_combination():
+def test_mcewkloss_combination(device):
     num_classes = 6
     C = 0.5
     penalization_type = "quadratic"
 
-    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type)
-    mce_loss = MCELoss(num_classes)
-    wk_loss = WKLoss(num_classes, penalization_type=penalization_type)
+    loss = MCEAndWKLoss(num_classes, C=C, wk_penalization_type=penalization_type).to(
+        device
+    )
+    mce_loss = MCELoss(num_classes).to(device)
+    wk_loss = WKLoss(num_classes, penalization_type=penalization_type).to(device)
+
+    loss_logits = MCEAndWKLoss(
+        num_classes, C=C, wk_penalization_type=penalization_type, use_logits=True
+    ).to(device)
+    mce_loss_logits = MCELoss(num_classes, use_logits=True).to(device)
+    wk_loss_logits = WKLoss(
+        num_classes, penalization_type=penalization_type, use_logits=True
+    ).to(device)
 
     input_data = torch.tensor(
         [
@@ -126,15 +184,23 @@ def test_mcewkloss_combination():
             [-0.2673, 0.0656, 0.7692, 1.4546, -0.3020, 0.3431],
             [0.8162, 1.3829, 0.1576, -0.1615, 1.2485, 0.2667],
         ]
-    )
+    ).to(device)
 
     # Error in classes 1 and 3 (pattern from class 1 classified as 3)
-    target = torch.tensor([3, 3, 1])
+    target = torch.tensor([3, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
-    output_mce = mce_loss(input_data, target)
-    output_wk = wk_loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_mce = mce_loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_wk = wk_loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_combined = C * output_mce + (1 - C) * output_wk
 
-    assert output.item() == output_combined.item()
+    output_logits = loss_logits(input_data, target)
+    output_mce_logits = mce_loss_logits(input_data, target)
+    output_wk_logits = wk_loss_logits(input_data, target)
+    output_combined_logits = C * output_mce_logits + (1 - C) * output_wk_logits
+
+    assert output.item() == pytest.approx(output_combined.item())
+    assert output_logits.item() == pytest.approx(output_combined_logits.item())
+    assert output.item() == pytest.approx(output_combined_logits.item())
+    assert output_logits.item() == pytest.approx(output_combined.item())

--- a/dlordinal/losses/tests/test_wkloss.py
+++ b/dlordinal/losses/tests/test_wkloss.py
@@ -4,16 +4,22 @@ import torch
 from dlordinal.losses import WKLoss
 
 
-def test_wkloss_creation():
-    loss = WKLoss(num_classes=6)
+@pytest.fixture
+def device():
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def test_wkloss_creation(device):
+    loss = WKLoss(num_classes=6).to(device)
     assert isinstance(loss, WKLoss)
 
 
-def test_wkloss_basic():
+def test_wkloss_basic(device):
     num_classes = 6
     penalization_type = "quadratic"
 
-    loss = WKLoss(num_classes, penalization_type)
+    loss = WKLoss(num_classes, penalization_type).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, use_logits=True).to(device)
 
     input_data = torch.tensor(
         [
@@ -21,25 +27,27 @@ def test_wkloss_basic():
             [-2.4079, -2.1725, -2.1459, -3.3318, -3.9624, -4.4700],
             [-2.4079, -1.7924, -2.0101, -4.1030, -3.3445, -4.4812],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([2, 2, 1])
+    target = torch.tensor([2, 2, 1]).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
-    # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
-
-    # Verifies that the loss is greater than zero
+    assert isinstance(output_logits, torch.Tensor)
     assert output.item() > 0
+    assert output_logits.item() > 0
+    assert output.item() == pytest.approx(output_logits.item(), rel=1e-6)
 
 
-def test_wkloss_basic_onehot():
+def test_wkloss_basic_onehot(device):
     num_classes = 6
     penalization_type = "quadratic"
 
-    loss = WKLoss(num_classes, penalization_type)
+    loss = WKLoss(num_classes, penalization_type).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, use_logits=True).to(device)
 
     input_data = torch.tensor(
         [
@@ -47,7 +55,7 @@ def test_wkloss_basic_onehot():
             [-2.4079, -2.1725, -2.1459, -3.3318, -3.9624, -4.4700],
             [-2.4079, -1.7924, -2.0101, -4.1030, -3.3445, -4.4812],
         ]
-    )
+    ).to(device)
 
     target = torch.tensor(
         [
@@ -55,27 +63,31 @@ def test_wkloss_basic_onehot():
             [0, 0, 1, 0, 0, 0],
             [0, 1, 0, 0, 0, 0],
         ]
-    )
+    ).to(device)
 
     # Compute the loss
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
-    # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
-
-    # Verifies that the loss is greater than zero
+    assert isinstance(output_logits, torch.Tensor)
     assert output.item() > 0
+    assert output_logits.item() > 0
+    assert output.item() == pytest.approx(output_logits.item(), rel=1e-6)
 
 
-def test_wkloss_custom_weight():
+def test_wkloss_custom_weight(device):
     num_classes = 6
     penalization_type = "quadratic"
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss = WKLoss(num_classes, penalization_type, weight)
+    loss = WKLoss(num_classes, penalization_type, weight).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, weight, use_logits=True).to(
+        device
+    )
 
     input_data = torch.tensor(
         [
@@ -83,28 +95,37 @@ def test_wkloss_custom_weight():
             [-2.4079, -2.5133, -2.6187, -2.6082, -1.8703, -2.4251],
             [-2.4079, -1.8561, -3.9906, -5.2992, -5.8944, -7.1456],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([2, 4, 1])
+    target = torch.tensor([2, 4, 1]).to(device)
 
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
+    assert isinstance(output_logits, torch.Tensor)
 
-    # Verifies that the loss is greater than zero
     assert output.item() > 0
+    assert output_logits.item() > 0
+    assert output.item() == pytest.approx(output_logits.item(), rel=1e-6)
 
 
-def test_wkloss_zeroloss():
+def test_wkloss_zeroloss(device):
     num_classes = 6
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss_quadratic = WKLoss(num_classes, "quadratic", weight)
-    loss_linear = WKLoss(num_classes, "linear", weight)
+    loss_quadratic = WKLoss(num_classes, "quadratic", weight).to(device)
+    loss_linear = WKLoss(num_classes, "linear", weight).to(device)
+    loss_quadratic_logits = WKLoss(
+        num_classes, "quadratic", weight, use_logits=True
+    ).to(device)
+    loss_linear_logits = WKLoss(num_classes, "linear", weight, use_logits=True).to(
+        device
+    )
 
     input_data = torch.tensor(
         [
@@ -113,31 +134,42 @@ def test_wkloss_zeroloss():
             [0.0, 0.0, 10000.0, 0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 0.0, 0.0, 10000.0],
         ]
+    ).to(device)
+
+    target = torch.tensor([0, 1, 2, 5]).to(device)
+
+    output_quadratic = loss_quadratic(
+        torch.nn.functional.softmax(input_data, dim=1), target
     )
-
-    target = torch.tensor([0, 1, 2, 5])
-
-    output_quadratic = loss_quadratic(input_data, target)
-    output_linear = loss_linear(input_data, target)
+    output_linear = loss_linear(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_quadratic_logits = loss_quadratic_logits(input_data, target)
+    output_linear_logits = loss_linear_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output_quadratic, torch.Tensor)
     assert isinstance(output_linear, torch.Tensor)
+    assert isinstance(output_quadratic_logits, torch.Tensor)
+    assert isinstance(output_linear_logits, torch.Tensor)
 
     # Check that the loss is zero
     assert output_quadratic.item() == pytest.approx(0.0, rel=1e-6)
     assert output_linear.item() == pytest.approx(0.0, rel=1e-6)
+    assert output_quadratic_logits.item() == pytest.approx(0.0, rel=1e-6)
+    assert output_linear_logits.item() == pytest.approx(0.0, rel=1e-6)
 
 
-def test_wkloss_exactloss_quadratic():
+def test_wkloss_exactloss_quadratic(device):
     num_classes = 6
     penalization_type = "quadratic"
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss = WKLoss(num_classes, penalization_type, weight)
+    loss = WKLoss(num_classes, penalization_type, weight).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, weight, use_logits=True).to(
+        device
+    )
 
     input_data = torch.tensor(
         [
@@ -152,28 +184,33 @@ def test_wkloss_exactloss_quadratic():
             [2.0113, 0.1522, 0.8675, -0.5035, -0.6438, 0.1304],
             [-0.4665, 1.9245, 1.6211, 0.7804, -0.9119, 0.8178],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([0, 4, 1, 3, 5, 4, 4, 3, 1, 2])
+    target = torch.tensor([0, 4, 1, 3, 5, 4, 4, 3, 1, 2]).to(device)
 
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
+    assert isinstance(output_logits, torch.Tensor)
 
-    # Verifies that the loss is greater than zero
-    assert output.item() == pytest.approx(1.1249, rel=1e-3)
+    assert output.item() == pytest.approx(0.5146, rel=1e-3)
+    assert output_logits.item() == pytest.approx(0.5146, rel=1e-3)
 
 
-def test_wkloss_exactloss_linear():
+def test_wkloss_exactloss_linear(device):
     num_classes = 6
     penalization_type = "linear"
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss = WKLoss(num_classes, penalization_type, weight)
+    loss = WKLoss(num_classes, penalization_type, weight).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, weight, use_logits=True).to(
+        device
+    )
 
     input_data = torch.tensor(
         [
@@ -188,28 +225,34 @@ def test_wkloss_exactloss_linear():
             [2.0113, 0.1522, 0.8675, -0.5035, -0.6438, 0.1304],
             [-0.4665, 1.9245, 1.6211, 0.7804, -0.9119, 0.8178],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([0, 4, 1, 3, 5, 4, 4, 3, 1, 2])
+    target = torch.tensor([0, 4, 1, 3, 5, 4, 4, 3, 1, 2]).to(device)
 
-    output = loss(input_data, target)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
+    assert isinstance(output_logits, torch.Tensor)
 
     # Verifies that the loss is greater than zero
-    assert output.item() == pytest.approx(0.7434, rel=1e-3)
+    assert output.item() == pytest.approx(0.6403, rel=1e-3)
+    assert output_logits.item() == pytest.approx(0.6403, rel=1e-3)
 
 
-def test_wkloss_relative():
+def test_wkloss_relative(device):
     num_classes = 6
     penalization_type = "quadratic"
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss = WKLoss(num_classes, penalization_type, weight)
+    loss = WKLoss(num_classes, penalization_type, weight).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, weight, use_logits=True).to(
+        device
+    )
 
     # Predicting the correct category
     input_data1 = torch.tensor(
@@ -221,7 +264,7 @@ def test_wkloss_relative():
             [0.0, 0.0, 0.0, 0.0, 10000.0, 0.0],
             [0.0, 0.0, 0.0, 0.0, 0.0, 10000.0],
         ]
-    )
+    ).to(device)
 
     # Predicting adjacent category
     input_data2 = torch.tensor(
@@ -233,7 +276,7 @@ def test_wkloss_relative():
             [0.0, 0.0, 0.0, 0.0, 0.0, 10000.0],
             [0.0, 0.0, 0.0, 0.0, 10000.0, 0.0],
         ]
-    )
+    ).to(device)
 
     # Predicting 2 categories away from target
     input_data3 = torch.tensor(
@@ -245,30 +288,44 @@ def test_wkloss_relative():
             [0.0, 0.0, 10000.0, 0.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 10000.0, 0.0, 0.0],
         ]
-    )
+    ).to(device)
 
-    target = torch.tensor([0, 1, 2, 3, 4, 5])
+    target = torch.tensor([0, 1, 2, 3, 4, 5]).to(device)
 
-    output1 = loss(input_data1, target)
-    output2 = loss(input_data2, target)
-    output3 = loss(input_data3, target)
+    output1 = loss(torch.nn.functional.softmax(input_data1, dim=1), target)
+    output2 = loss(torch.nn.functional.softmax(input_data2, dim=1), target)
+    output3 = loss(torch.nn.functional.softmax(input_data3, dim=1), target)
+
+    output1_logits = loss_logits(input_data1, target)
+    output2_logits = loss_logits(input_data2, target)
+    output3_logits = loss_logits(input_data3, target)
 
     assert isinstance(output1, torch.Tensor)
     assert isinstance(output2, torch.Tensor)
     assert isinstance(output3, torch.Tensor)
+    assert isinstance(output1_logits, torch.Tensor)
+    assert isinstance(output2_logits, torch.Tensor)
+    assert isinstance(output3_logits, torch.Tensor)
 
     assert output1.item() < output2.item() < output3.item()
+    assert output1_logits.item() < output2_logits.item() < output3_logits.item()
 
 
-def test_wkloss_penalization_types():
+def test_wkloss_penalization_types(device):
     num_classes = 6
     weight = torch.tensor(
         [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
         dtype=torch.float,
-    )
+    ).to(device)
 
-    loss_quadratic = WKLoss(num_classes, "quadratic", weight)
-    loss_linear = WKLoss(num_classes, "linear", weight)
+    loss_quadratic = WKLoss(num_classes, "quadratic", weight).to(device)
+    loss_linear = WKLoss(num_classes, "linear", weight).to(device)
+    loss_quadratic_logits = WKLoss(
+        num_classes, "quadratic", weight, use_logits=True
+    ).to(device)
+    loss_linear_logits = WKLoss(num_classes, "linear", weight, use_logits=True).to(
+        device
+    )
 
     input_data = torch.tensor(
         [
@@ -283,35 +340,53 @@ def test_wkloss_penalization_types():
             [2.0113, 0.1522, 0.8675, -0.5035, -0.6438, 0.1304],
             [-0.4665, 1.9245, 1.6211, 0.7804, -0.9119, 0.8178],
         ]
+    ).to(device)
+
+    target = torch.tensor([5, 0, 0, 5, 1, 0, 2, 0, 5, 5]).to(device)
+
+    output_quadratic = loss_quadratic(
+        torch.nn.functional.softmax(input_data, dim=1), target
     )
-
-    target = torch.tensor([5, 0, 0, 5, 1, 0, 2, 0, 5, 5])
-
-    output_quadratic = loss_quadratic(input_data, target)
-    output_linear = loss_linear(input_data, target)
+    output_linear = loss_linear(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_quadratic_logits = loss_quadratic_logits(input_data, target)
+    output_linear_logits = loss_linear_logits(input_data, target)
 
     assert isinstance(output_quadratic, torch.Tensor)
     assert isinstance(output_linear, torch.Tensor)
+    assert isinstance(output_quadratic_logits, torch.Tensor)
+    assert isinstance(output_linear_logits, torch.Tensor)
 
     assert output_quadratic.item() > output_linear.item()
+    assert output_quadratic_logits.item() > output_linear_logits.item()
 
 
-def test_wkloss_weights():
+def test_wkloss_weights(device):
     num_classes = 6
     penalization_types = ["linear", "quadratic"]
     weight = torch.tensor(
         [1.0, 1.0, 1.0, 1.0, 1.0, 5.0],
         dtype=torch.float,
-    )
+    ).to(device)
     weight2 = torch.tensor(
         [1.0, 1.0, 1.0, 1.0, 1.0, 10.0],
         dtype=torch.float,
-    )
+    ).to(device)
 
     for penalization_type in penalization_types:
-        loss = WKLoss(num_classes, penalization_type, weight=None)
-        loss_weighted = WKLoss(num_classes, penalization_type, weight=weight)
-        loss_weighted2 = WKLoss(num_classes, penalization_type, weight=weight2)
+        loss = WKLoss(num_classes, penalization_type, weight=None).to(device)
+        loss_weighted = WKLoss(num_classes, penalization_type, weight=weight).to(device)
+        loss_weighted2 = WKLoss(num_classes, penalization_type, weight=weight2).to(
+            device
+        )
+        loss_logits = WKLoss(
+            num_classes, penalization_type, weight=None, use_logits=True
+        ).to(device)
+        loss_weighted_logits = WKLoss(
+            num_classes, penalization_type, weight=weight, use_logits=True
+        ).to(device)
+        loss_weighted2_logits = WKLoss(
+            num_classes, penalization_type, weight=weight2, use_logits=True
+        ).to(device)
 
         # Input data with error in two samples of class 5 (highest weight)
         input_data = torch.tensor(
@@ -324,7 +399,7 @@ def test_wkloss_weights():
                 [0.0, 10000.0, 0.0, 0.0, 0.0, 0.0],
                 [0.0, 10000.0, 0.0, 0.0, 0.0, 0.0],
             ]
-        )
+        ).to(device)
 
         input_data2 = torch.tensor(
             [
@@ -336,31 +411,91 @@ def test_wkloss_weights():
                 [0.0, 0.0, 0.0, 0.0, 0.0, 10000.0],
                 [0.0, 0.0, 0.0, 0.0, 0.0, 10000.0],
             ]
+        ).to(device)
+
+        target = torch.tensor([0, 1, 2, 3, 4, 5, 5]).to(device)
+
+        output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+        output_weighted = loss_weighted(
+            torch.nn.functional.softmax(input_data, dim=1), target
+        )
+        output_weighted2 = loss_weighted2(
+            torch.nn.functional.softmax(input_data, dim=1), target
         )
 
-        target = torch.tensor([0, 1, 2, 3, 4, 5, 5])
+        output2 = loss(torch.nn.functional.softmax(input_data2, dim=1), target)
+        output2_weighted = loss_weighted(
+            torch.nn.functional.softmax(input_data2, dim=1), target
+        )
+        output2_weighted2 = loss_weighted2(
+            torch.nn.functional.softmax(input_data2, dim=1), target
+        )
 
-        output = loss(input_data, target)
-        output_weighted = loss_weighted(input_data, target)
-        output_weighted2 = loss_weighted2(input_data, target)
+        output_logits = loss_logits(input_data, target)
+        output_weighted_logits = loss_weighted_logits(input_data, target)
+        output_weighted2_logits = loss_weighted2_logits(input_data, target)
 
-        output2 = loss(input_data2, target)
-        output2_weighted = loss_weighted(input_data2, target)
-        output2_weighted2 = loss_weighted2(input_data2, target)
+        output2_logits = loss_logits(input_data2, target)
+        output2_weighted_logits = loss_weighted_logits(input_data2, target)
+        output2_weighted2_logits = loss_weighted2_logits(input_data2, target)
 
         # Test return type
         assert isinstance(output, torch.Tensor)
         assert isinstance(output_weighted, torch.Tensor)
         assert isinstance(output_weighted2, torch.Tensor)
+        assert isinstance(output2, torch.Tensor)
+        assert isinstance(output2_weighted, torch.Tensor)
+        assert isinstance(output2_weighted2, torch.Tensor)
 
         # Test that using class weight with errors increases the loss
         assert output_weighted.item() > output.item()
+        assert output_weighted_logits.item() > output_logits.item()
 
         # When using a higher weight in the class with errors, the loss increases
         assert output_weighted2.item() > output_weighted.item()
+        assert output_weighted2_logits.item() > output_weighted_logits.item()
 
         # When having an error in a class with not highest weight, the loss decreases
         assert output2_weighted.item() < output2.item()
+        assert output2_weighted_logits.item() < output2_logits.item()
 
         # If the cost of the other class increases, the loss decreases
         assert output2_weighted2.item() < output2_weighted.item()
+        assert output2_weighted2_logits.item() < output2_weighted_logits.item()
+
+
+def test_wkloss_input_errors(device):
+    num_classes = 6
+    penalization_type = "quadratic"
+    weight = torch.tensor(
+        [1.60843373, 0.55394191, 1.02692308, 0.78070175, 1.12184874, 2.34210526],
+        dtype=torch.float,
+    ).to(device)
+
+    loss = WKLoss(num_classes, penalization_type, weight).to(device)
+    loss_logits = WKLoss(num_classes, penalization_type, weight, use_logits=True).to(
+        device
+    )
+
+    input_data = torch.tensor(
+        [
+            [1.1182, -1.4991, -1.6639, -2.6338, 1.0638, -1.7242],
+            [0.0584, 0.8491, 0.4281, -0.1311, 0.3988, 0.9868],
+            [0.1456, -0.6615, -0.7971, -0.6217, 1.5191, 1.2822],
+            [-1.1213, -0.1885, 0.4632, -1.0184, -0.4659, -0.0324],
+            [-1.9973, -1.9622, -0.7560, -0.1352, 0.3598, 0.9245],
+            [-0.4714, 0.9953, 0.3056, 1.4104, -0.3741, -1.4388],
+            [-0.0293, -1.6450, -1.4326, -0.3240, 1.1304, 2.6315],
+            [1.2635, 0.4663, -0.2953, 1.1983, -1.0992, -1.1091],
+            [2.0113, 0.1522, 0.8675, -0.5035, -0.6438, 0.1304],
+            [-0.4665, 1.9245, 1.6211, 0.7804, -0.9119, 0.8178],
+        ]
+    ).to(device)
+
+    target = torch.tensor([5, 0, 0, 5, 1, 0, 2, 0, 5, 5]).to(device)
+
+    with pytest.raises(ValueError):
+        loss(input_data, target)
+
+    with pytest.raises(ValueError):
+        loss_logits(torch.nn.functional.softmax(input_data, dim=1), target)

--- a/dlordinal/losses/wkloss.py
+++ b/dlordinal/losses/wkloss.py
@@ -75,8 +75,7 @@ class WKLoss(nn.Module):
             self.first_forward = False
 
         if self.use_logits:
-            y_pred_max = torch.max(y_pred, dim=1, keepdim=True).values
-            y_pred = torch.exp(y_pred - y_pred_max)
+            y_pred = torch.nn.functional.softmax(y_pred, dim=1)
 
         repeat_op = (
             torch.Tensor(list(range(num_classes))).unsqueeze(1).repeat((1, num_classes))

--- a/dlordinal/losses/wkloss.py
+++ b/dlordinal/losses/wkloss.py
@@ -30,6 +30,7 @@ class WKLoss(nn.Module):
         penalization_type: str = "quadratic",
         weight: Optional[torch.Tensor] = None,
         epsilon: Optional[float] = 1e-10,
+        use_logits=False,
     ):
         super(WKLoss, self).__init__()
         self.num_classes = num_classes
@@ -40,6 +41,8 @@ class WKLoss(nn.Module):
 
         self.epsilon = epsilon
         self.weight = weight
+        self.use_logits = use_logits
+        self.first_forward = True
 
     def forward(self, y_pred, y_true):
         num_classes = self.num_classes
@@ -50,6 +53,26 @@ class WKLoss(nn.Module):
             y_true = y[y_true]
 
         y_true = y_true.float()
+
+        if self.first_forward:
+            if not self.use_logits and not torch.allclose(
+                y_pred.sum(dim=1), torch.tensor(1.0, device=y_pred.device)
+            ):
+                raise ValueError(
+                    "When passing use_logits=False, the input y_pred"
+                    " should be probabilities, not logits."
+                )
+            elif self.use_logits and torch.allclose(
+                y_pred.sum(dim=1), torch.tensor(1.0, device=y_pred.device)
+            ):
+                raise ValueError(
+                    "When passing use_logits=True, the input y_pred"
+                    " should be logits, not probabilities."
+                )
+            self.first_forward = False
+
+        if self.use_logits:
+            y_pred = torch.nn.functional.softmax(y_pred, dim=1)
 
         repeat_op = (
             torch.Tensor(list(range(num_classes))).unsqueeze(1).repeat((1, num_classes))

--- a/dlordinal/losses/wkloss.py
+++ b/dlordinal/losses/wkloss.py
@@ -22,6 +22,9 @@ class WKLoss(nn.Module):
         Increment to avoid log zero,
         so the loss will be :math:`\\log(1 - k + \\epsilon)`, where :math:`k` lies
         in :math:`[-1, 1]`. Defaults to ``1e-10``.
+    use_logits : bool, default=False
+        If True, the input y_pred will be treated as logits.
+        If False, the input y_pred will be treated as probabilities.
     """
 
     def __init__(
@@ -72,7 +75,8 @@ class WKLoss(nn.Module):
             self.first_forward = False
 
         if self.use_logits:
-            y_pred = torch.nn.functional.softmax(y_pred, dim=1)
+            y_pred_max = torch.max(y_pred, dim=1, keepdim=True).values
+            y_pred = torch.exp(y_pred - y_pred_max)
 
         repeat_op = (
             torch.Tensor(list(range(num_classes))).unsqueeze(1).repeat((1, num_classes))


### PR DESCRIPTION
Previously, `WKLoss` required a probabilistic input to work properly. Given that, in PyTorch, models usually output logits, I have included the `use_logits` parameter to support logit inputs. When this parameter is set to `True`, the softmax of the input is computed before computing the loss. If `False`, the raw inputs are used.