### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The source code for all [releases](https://github.com/ayrna/dlordinal/releases) is available on GitHub.
 
+- [version 2.4.0](./changelog_versions/version_2-4-0.md)
 - [version 2.3.2](./changelog_versions/version_2-3-2.md)
 - [Version 2.3.1](./changelog_versions/version_2-3-1.md)
 - [Version 2.3.0](./changelog_versions/version_2-3-0.md)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `dlordinal` is a Python library that unifies many recent deep ordinal classification methodologies available in the literature. Developed using PyTorch as underlying framework, it implements the top performing state-of-the-art deep learning techniques for ordinal classification problems. Ordinal approaches are designed to leverage the ordering information present in the target variable. Specifically, it includes loss functions, various output layers, dropout techniques, soft labelling methodologies, and other classification strategies, all of which are appropriately designed to incorporate the ordinal information. Furthermore, as the performance metrics to assess novel proposals in ordinal classification depend on the distance between target and predicted classes in the ordinal scale, suitable ordinal evaluation metrics are also included.
 
-The latest `dlordinal` release is `v2.3.2`. You can view all the changes made in the current and previous versions in the [CHANGELOG](./CHANGELOG.md).
+The latest `dlordinal` release is `v2.4.0`. You can view all the changes made in the current and previous versions in the [CHANGELOG](./CHANGELOG.md).
 
 | Overview  |                                                                                                                                          |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------|
@@ -11,7 +11,7 @@ The latest `dlordinal` release is `v2.3.2`. You can view all the changes made in
 
 
 ## Table of Contents
-- [Welcome to dlordinal](#welcome-to-dlordinal)
+- [Welcome to `dlordinal`](#welcome-to-dlordinal)
   - [Table of Contents](#table-of-contents)
   - [⚙️ Installation](#️-installation)
   - [🚀 Getting started](#-getting-started)
@@ -24,7 +24,7 @@ The latest `dlordinal` release is `v2.3.2`. You can view all the changes made in
 
 ## ⚙️ Installation
 
-`dlordinal v2.3.2` is the last version, supported from Python 3.8 to Python 3.12.
+`dlordinal v2.4.0` is the last version, supported from Python 3.8 to Python 3.12.
 
 The easiest way to install `dlordinal` is via `pip`:
 

--- a/changelog_versions/version_2-4-0.md
+++ b/changelog_versions/version_2-4-0.md
@@ -1,0 +1,35 @@
+# v2.4.0
+
+**April 2025**
+
+`dlordinal` **v2.4.0** includes the following updates:
+
+---
+
+## Loss Functions
+- Implemented the **CDWCE** loss function.
+- Fixed an issue in **WKLoss** that prevented it from working when `y_true` was one-hot encoded.
+- Resolved a device inconsistency in the `WKLoss.forward` method.
+- Added **squared Earth Mover’s Distance (EMD)** loss.
+- Extended **WKLoss** to support both logits and probabilities (previously supported only probabilities).
+
+---
+
+## Soft Labelling
+- Added examples for **geometric soft labels**.
+- **Refactored soft labelling losses**:
+  These have been reimplemented to support arbitrary loss functions, not just `CrossEntropyLoss`. Additionally, they have been renamed for clarity:
+  - `BetaCrossEntropyLoss` → `BetaLoss`
+  - `BinomialCrossEntropyLoss` → `BinomialLoss`
+  - `CustomTargetsCrossEntropyLoss` → `CustomTargetsLoss`
+  - `ExponentialCrossEntropyLoss` → `ExponentialLoss`
+  - `GeneralTriangularCrossEntropyLoss` → `GeneralTriangularLoss`
+  - `PoissonCrossEntropyLoss` → `PoissonLoss`
+  - `TriangularCrossEntropyLoss` → `TriangularLoss`
+
+> ⚠️ The original soft labelling loss classes are now **deprecated** and scheduled for removal in **v3.0.0**.
+
+---
+
+## Maintenance
+- Added GPU-enabled versions of all test cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dlordinal"
-version = "2.3.2"
+version = "2.4.0"
 authors = [
     {name = "Francisco Bérchez-Moreno", email = "fberchez@uco.es"},
     {name = "Víctor Manuel Vargas", email = "vvargas@uco.es"},


### PR DESCRIPTION
# v2.4.0

**April 2025**

`dlordinal` **v2.4.0** includes the following updates:

---

## Loss Functions
- Implemented the **CDWCE** loss function.
- Fixed an issue in **WKLoss** that prevented it from working when `y_true` was one-hot encoded.
- Resolved a device inconsistency in the `WKLoss.forward` method.
- Added **squared Earth Mover’s Distance (EMD)** loss.
- Extended **WKLoss** to support both logits and probabilities (previously supported only probabilities).

---

## Soft Labelling
- Added examples for **geometric soft labels**.
- **Refactored soft labelling losses**:
  These have been reimplemented to support arbitrary loss functions, not just `CrossEntropyLoss`. Additionally, they have been renamed for clarity:
  - `BetaCrossEntropyLoss` → `BetaLoss`
  - `BinomialCrossEntropyLoss` → `BinomialLoss`
  - `CustomTargetsCrossEntropyLoss` → `CustomTargetsLoss`
  - `ExponentialCrossEntropyLoss` → `ExponentialLoss`
  - `GeneralTriangularCrossEntropyLoss` → `GeneralTriangularLoss`
  - `PoissonCrossEntropyLoss` → `PoissonLoss`
  - `TriangularCrossEntropyLoss` → `TriangularLoss`

> ⚠️ The original soft labelling loss classes are now **deprecated** and scheduled for removal in **v3.0.0**.

---

## Maintenance
- Added GPU-enabled versions of all test cases.
