### PR TITLE
[ENH] Allow `get_beta_soft_labels` to accept custom `params_set`

### DIFF
--- a/dlordinal/losses/beta_loss.py
+++ b/dlordinal/losses/beta_loss.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, List, Optional, Union
 
 import torch
 from deprecated.sphinx import deprecated
@@ -52,7 +52,7 @@ class BetaLoss(CustomTargetsLoss):
         self,
         base_loss: Module,
         num_classes: int,
-        params_set: str | dict[int, list] = "standard",
+        params_set: Union[str, Dict[int, List]] = "standard",
         eta: float = 1.0,
     ):
         # Precompute class probabilities for each label

--- a/dlordinal/losses/beta_loss.py
+++ b/dlordinal/losses/beta_loss.py
@@ -20,9 +20,18 @@ class BetaLoss(CustomTargetsLoss):
         (e.g., one-hot or soft labels).
     num_classes : int
         Number of classes.
-    params_set : str, default='standard'
-        The set of parameters to use for the beta distribution (chosen from the
-        _beta_params_set dictionary).
+    params_set : str or dict[int, list], default="standard"
+            The set of parameters of the beta distributions employed to generate the
+            soft labels. It can be one of the keys in the ``_beta_params_sets``
+            dictionary. Alternatively, it can be a dictionary with the same structure as
+            the items of the ``_beta_params_sets`` dictionary. The keys of the dictionary
+            must be the number of classes and the values must be a list of lists with
+            the parameters of the beta distributions for each class. The list for each class
+            must have three parameters :math:`[p,q,a]` where :math:`p` and :math:`q` are the
+            shape parameters of the beta distribution and :math:`a` is the scaling
+            parameter. Example: ``{3: [[1, 4, 1], [4, 4, 1], [4, 1, 1]]}`` for three classes
+            with the parameters :math:`[1,4,1]`, :math:`[4,4,1]` and :math:`[4,1,1]` for each
+            class respectively.
     eta : float, default=1.0
         Parameter that controls the influence of the regularisation.
 
@@ -43,7 +52,7 @@ class BetaLoss(CustomTargetsLoss):
         self,
         base_loss: Module,
         num_classes: int,
-        params_set: str = "standard",
+        params_set: str | dict[int, list] = "standard",
         eta: float = 1.0,
     ):
         # Precompute class probabilities for each label

--- a/dlordinal/losses/tests/test_beta_loss.py
+++ b/dlordinal/losses/tests/test_beta_loss.py
@@ -145,3 +145,29 @@ def test_beta_loss_weights(device):
     loss3 = loss(input_data, target3)
 
     assert loss1.item() > loss2.item() > loss3.item()
+
+
+@pytest.mark.parametrize("J", [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+def test_beta_loss_custom_params_set(device, J):
+    from dlordinal.soft_labelling.beta_distribution import _beta_params_sets
+
+    base_loss = CrossEntropyLoss().to(device)
+
+    loss_standard = BetaLoss(
+        base_loss=base_loss, num_classes=J, params_set="standard"
+    ).to(device)
+
+    params = _beta_params_sets["standard"]
+    loss_custom = BetaLoss(
+        base_loss=base_loss,
+        num_classes=J,
+        params_set=params,
+    ).to(device)
+
+    input_data = torch.rand(20, J).to(device)
+    target = torch.randint(0, J, (20,)).to(device)
+
+    output_standard = loss_standard(input_data, target)
+    output_custom = loss_custom(input_data, target)
+
+    assert output_standard.item() == output_custom.item()

--- a/dlordinal/soft_labelling/beta_distribution.py
+++ b/dlordinal/soft_labelling/beta_distribution.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Union
+
 import numpy as np
 from scipy.special import gamma, hyp2f1
 
@@ -234,7 +236,7 @@ _beta_params_sets = {
 }
 
 
-def get_beta_soft_labels(J: int, params_set: str | dict[int, list] = "standard"):
+def get_beta_soft_labels(J: int, params_set: Union[str, Dict[int, List]] = "standard"):
     """Get soft labels for each of the ``J`` classes using a beta distributions and
     the parameter defined in the ``params_set`` as described in :footcite:t:`vargas2022unimodal`.
 

--- a/dlordinal/soft_labelling/tests/test_beta_distribution.py
+++ b/dlordinal/soft_labelling/tests/test_beta_distribution.py
@@ -3,28 +3,28 @@ import pytest
 
 from dlordinal.soft_labelling import get_beta_soft_labels
 from dlordinal.soft_labelling.beta_distribution import (
+    _beta_dist,
+    _beta_func,
     _get_beta_soft_label,
-    beta_dist,
-    beta_func,
 )
 
 
 def test_beta_inc():
     # Case 1: Positive Values
-    result = beta_func(2.0, 3.0)
+    result = _beta_func(2.0, 3.0)
     print(result)
     expected_result = 0.08333333333333333
     assert result == pytest.approx(expected_result, rel=1e-6)
 
     # Case 2: Avoid division by 0
     with pytest.raises(ValueError):
-        result = beta_func(0.0, 0.0)
+        result = _beta_func(0.0, 0.0)
 
 
 @pytest.mark.parametrize("a, b", [(-1.0, 2.0), (1.0, -2.0), (-1.0, -2.0)])
 def test_beta_inc_negative_values(a, b):
     with pytest.raises(ValueError):
-        beta_func(a, b)
+        _beta_func(a, b)
 
 
 def test_beta_dist():
@@ -33,27 +33,27 @@ def test_beta_dist():
     p = 2.0
     q = 3.0
     a = 1.0
-    result = beta_dist(x, p, q, a)
+    result = _beta_dist(x, p, q, a)
     expected_result = 0.6875
     assert result == pytest.approx(expected_result, rel=1e-6)
 
     # Case 2: Custom scaling parameter
     a = 2.0
-    result = beta_dist(x, p, q, a)
+    result = _beta_dist(x, p, q, a)
     expected_result = 0.26171875
     assert result == pytest.approx(expected_result, rel=1e-6)
 
     # Case 3: Check probabilities with custom x
     x_array = np.linspace(0, 1, num=101)
     for x in x_array:
-        result = beta_dist(x, p, q, a)
+        result = _beta_dist(x, p, q, a)
         assert result >= 0.0 or result <= 1.0
 
 
 @pytest.mark.parametrize("x", [-1.0, 2.0])
 def test_beta_distribution_negative_x(x):
     with pytest.raises(ValueError):
-        beta_dist(x, 2.0, 3.0, 1.0)
+        _beta_dist(x, 2.0, 3.0, 1.0)
 
 
 def test_beta_soft_label():
@@ -140,3 +140,88 @@ def test_beta_softlabels():
     for r, e in zip(result, expected_result):
         for r_, e_ in zip(r, e):
             assert r_ == pytest.approx(e_, rel=1e-6)
+
+
+def test_beta_softlabels_invalid_params():
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(0)
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set="invalid")
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set={"test": [[1, 2, 3]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set={4: [[1, 2, 3]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set={3: [[1, 2]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set={3: [[1, 2, 3], [4, 5]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(3, params_set={3: [[1, 2, 3], [4, 5, 6], [7]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(4, params_set={4: [[1, 2, 3], [4, 5, 6], [7, 8, 9]]})
+
+    with pytest.raises(ValueError):
+        get_beta_soft_labels(4, params_set=10)
+
+
+@pytest.mark.parametrize("J", [3, 4, 5, 6, 7, 8, 9, 10])
+def test_beta_softlabels_custom_params(J):
+    params = {
+        3: [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        4: [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
+        5: [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]],
+        6: [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15], [16, 17, 18]],
+        7: [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21],
+        ],
+        8: [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21],
+            [22, 23, 24],
+        ],
+        9: [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21],
+            [22, 23, 24],
+            [25, 26, 27],
+        ],
+        10: [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21],
+            [22, 23, 24],
+            [25, 26, 27],
+            [28, 29, 30],
+        ],
+    }
+    result = get_beta_soft_labels(J, params_set=params)
+
+    assert result.ndim == 2
+    assert result.shape == (J, J)

--- a/dlordinal/soft_labelling/tests/test_beta_distribution.py
+++ b/dlordinal/soft_labelling/tests/test_beta_distribution.py
@@ -225,3 +225,13 @@ def test_beta_softlabels_custom_params(J):
 
     assert result.ndim == 2
     assert result.shape == (J, J)
+
+
+@pytest.mark.parametrize("J", [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+def test_beta_softlabels_custom_params_2(J):
+    from dlordinal.soft_labelling.beta_distribution import _beta_params_sets
+
+    params = _beta_params_sets["standard"]
+    result_standard = get_beta_soft_labels(J, params_set="standard")
+    result_custom = get_beta_soft_labels(J, params_set=params)
+    assert result_standard == pytest.approx(result_custom, rel=1e-6)


### PR DESCRIPTION
Modified `get_beta_soft_labels` to accept a custom `params_set` dictionary. The dictionary must use the number of classes (as integers) as keys, and provide a list of parameters `p`, `q` and `a` (one per class) as values.