### PR TITLE
[MNT] Add version consistency check script

### DIFF
--- a/.github/scripts/check_version_consistency.py
+++ b/.github/scripts/check_version_consistency.py
@@ -1,0 +1,45 @@
+import re
+import sys
+from pathlib import Path
+
+
+def extract_version_from_pyproject():
+    content = Path("pyproject.toml").read_text()
+    match = re.search(r'version\s*=\s*"(.+?)"', content)
+    return match.group(1) if match else None
+
+
+def extract_version_from_init():
+    content = Path("dlordinal/__init__.py").read_text()
+    match = re.search(r'__version__\s*=\s*["\'](.+?)["\']', content)
+    return match.group(1) if match else None
+
+
+def extract_versions_from_readme():
+    content = Path("README.md").read_text()
+    matches = re.findall(r"v([0-9]+\.[0-9]+\.[0-9]+)", content, re.IGNORECASE)
+    return matches
+
+
+def get_versions_set():
+    pyproject_version = extract_version_from_pyproject()
+    init_version = extract_version_from_init()
+    readme_version = extract_versions_from_readme()
+
+    print(f"pyproject.toml: {pyproject_version}")
+    print(f"__init__.py: {init_version}")
+    print(f"README.md: {readme_version}")
+
+    versions = {pyproject_version, init_version, *readme_version}
+
+    return versions
+
+
+if __name__ == "__main__":
+    versions = get_versions_set()
+
+    if None in versions or len(versions) != 1:
+        print("❌ Version mismatch detected!")
+        sys.exit(1)
+
+    print("✅ Versions match.")

--- a/.github/scripts/check_version_consistency_release.py
+++ b/.github/scripts/check_version_consistency_release.py
@@ -1,0 +1,28 @@
+import os
+import re
+import sys
+
+from check_version_consistency import get_versions_set
+
+release_title = os.environ.get("RELEASE_TITLE")
+if not release_title:
+    print(
+        "❌ RELEASE_TITLE environment variable not set. Please check that you have set "
+        "the release title appropriately."
+    )
+    sys.exit(1)
+
+versions = get_versions_set()
+matches = re.findall(r"([0-9]+\.[0-9]+\.[0-9]+)", release_title)
+release_version = matches[0] if matches else None
+versions.add(release_version)
+
+print(f"Release title: {release_title}")
+print(f"Versions found in files: {versions}")
+print(f"Release version: {release_version}")
+
+if len(versions) != 1:
+    print("❌ Version mismatch detected!")
+    sys.exit(1)
+
+print("✅ Versions match.")

--- a/.github/workflows/fast_release.yml
+++ b/.github/workflows/fast_release.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Run version check
+        run: python .github/scripts/check_version.py
+
       - name: Build project
         run: |
           python -m pip install build

--- a/.github/workflows/fast_release.yml
+++ b/.github/workflows/fast_release.yml
@@ -16,8 +16,7 @@ jobs:
           python-version: "3.10"
 
       - name: Run version check
-        run: python .github/scripts/check_version.py
-
+        run: python .github/scripts/check_version_consistency.py
       - name: Build project
         run: |
           python -m pip install build

--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -64,3 +64,6 @@ jobs:
           commit_message: Automatic `pre-commit` fixes
           commit_user_name: ayrna-actions-bot[bot]
           create_branch: false
+
+      - name: Run version check
+        run: python .github/scripts/check_version.py

--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -66,4 +66,4 @@ jobs:
           create_branch: false
 
       - name: Run version check
-        run: python .github/scripts/check_version.py
+        run: python .github/scripts/check_version_consistency.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.10"
 
       - name: Run version check
-        run: python .github/scripts/check_version_release.py
+        run: python .github/scripts/check_version_consistency_release.py
         env:
           RELEASE_TITLE: ${{ github.event.release.name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
 
 jobs:
   # check-manifest:
@@ -31,6 +30,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - name: Run version check
+        run: python .github/scripts/check_version_release.py
+        env:
+          RELEASE_TITLE: ${{ github.event.release.name }}
 
       - name: Build project
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,11 @@ repos:
       - id: nbqa-black
         additional_dependencies: [ black==24.10.0 ]
         args: []
+
+  - repo: local
+    hooks:
+      - id: check-version-consistency
+        name: Check version consistency across files
+        entry: python .github/scripts/check_version_consistency.py
+        language: system
+        types: [file]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `dlordinal` is a Python library that unifies many recent deep ordinal classification methodologies available in the literature. Developed using PyTorch as underlying framework, it implements the top performing state-of-the-art deep learning techniques for ordinal classification problems. Ordinal approaches are designed to leverage the ordering information present in the target variable. Specifically, it includes loss functions, various output layers, dropout techniques, soft labelling methodologies, and other classification strategies, all of which are appropriately designed to incorporate the ordinal information. Furthermore, as the performance metrics to assess novel proposals in ordinal classification depend on the distance between target and predicted classes in the ordinal scale, suitable ordinal evaluation metrics are also included.
 
-The latest `dlordinal` release is `v2.4.0`. You can view all the changes made in the current and previous versions in the [CHANGELOG](./CHANGELOG.md).
+The latest `dlordinal` release is `v2.4.1`. You can view all the changes made in the current and previous versions in the [CHANGELOG](./CHANGELOG.md).
 
 | Overview  |                                                                                                                                          |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
This PR introduces a script that ensures the version number is consistent across the following files:
- `pyproject.toml`
- `dlordinal/__init__.py`
- `README.md`

The script is integrated into:
- The `pre-commit` hook (to catch inconsistencies before committing)
- The GitHub Actions workflow (triggered on PR or release events)

This helps prevent accidental mismatches between the declared version and published metadata.