### PR TITLE
Replace CLM clipping by stable sigmoid when using logit link function

### DIFF
--- a/dlordinal/output_layers/tests/test_clm.py
+++ b/dlordinal/output_layers/tests/test_clm.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 import torch
@@ -97,44 +95,3 @@ def test_clm_all_combinations(device):
                 assert clm.min_distance == min_distance
 
                 _test_probas(clm, device)
-
-
-def test_clm_clip(device):
-    input_shape = 12
-    num_classes = 6
-    link_function = "cloglog"
-    min_distance = 0.0
-
-    clm = CLM(
-        num_classes=num_classes,
-        link_function=link_function,
-        min_distance=min_distance,
-        clip_warning=True,
-    ).to(device)
-    input_data = torch.rand(8, input_shape).to(device) * 100
-    with pytest.warns(Warning, match="Clipping"):
-        clm(input_data)
-
-    warnings.filterwarnings("error")
-    clm(input_data)
-    _test_probas(clm, device)
-
-    clm = CLM(
-        num_classes=num_classes,
-        link_function=link_function,
-        min_distance=min_distance,
-        clip_warning=False,
-    ).to(device)
-    clm(input_data)
-    _test_probas(clm, device)
-
-    clm = CLM(
-        num_classes=num_classes,
-        link_function=link_function,
-        min_distance=min_distance,
-        clip_warning=True,
-    ).to(device)
-    input_data = torch.rand(8, input_shape).to(device) * 0.1
-    clm(input_data)
-    _test_probas(clm, device)
-    warnings.resetwarnings()

--- a/dlordinal/output_layers/utils.py
+++ b/dlordinal/output_layers/utils.py
@@ -1,11 +1,16 @@
 import torch
 
 
-def stable_sigmoid(t):
+def stable_sigmoid(t: torch.Tensor) -> torch.Tensor:
     """
     Stable sigmoid function that avoids overflow issues for large values of t.
     This function is used to compute the sigmoid of a tensor t, handling both positive
     and negative values in a numerically stable way.
+
+    Parameters
+    ----------
+    t : torch.Tensor
+        Input tensor
     """
     idx = t > 0
     out = torch.zeros_like(t)

--- a/dlordinal/output_layers/utils.py
+++ b/dlordinal/output_layers/utils.py
@@ -1,0 +1,15 @@
+import torch
+
+
+def stable_sigmoid(t):
+    """
+    Stable sigmoid function that avoids overflow issues for large values of t.
+    This function is used to compute the sigmoid of a tensor t, handling both positive
+    and negative values in a numerically stable way.
+    """
+    idx = t > 0
+    out = torch.zeros_like(t)
+    out[idx] = 1.0 / (1 + torch.exp(-t[idx]))
+    exp_t = torch.exp(t[~idx])
+    out[~idx] = exp_t / (1.0 + exp_t)
+    return out


### PR DESCRIPTION
When using the `logit` link function in the `CLM` output layer, the method can be numerically unstable due to the `sigmoid` function computation. In this way, a new stable version of the `sigmoid` function is implemented, called `stable_sigmoid()`.
Therefore, `clip_warning` parameter of the `CLM` is removed, given that clipping the values of the projection is no longer required to ensure the stability of the model.
