### PR TITLE
[BUG] Fixed losses forward parameters order

### DIFF
--- a/dlordinal/losses/mcewkloss.py
+++ b/dlordinal/losses/mcewkloss.py
@@ -26,12 +26,12 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
         of size `J`, where `J` is the number of classes. Otherwise, it is treated
         as if having all ones.
     reduction : str, default='mean'
-        Specifies the reduction to apply to the output: ``'none'`` | ``'mean'`` |
+        Specifies the reduction to apply to the target: ``'none'`` | ``'mean'`` |
         ``'sum'``. ``'none'``: no reduction will be applied, ``'mean'``: the sum
-        of the output will be divided by the number of elements in the output,
-        ``'sum'``: the output will be summed.
+        of the target will be divided by the number of elements in the target,
+        ``'sum'``: the target will be summed.
     use_logits : bool, default=False
-        If True, the input `y_pred` will be treated as logits. If False, it will be
+        If True, the `input` will be treated as logits. If False, it will be
         treated as probabilities.
 
     Example
@@ -40,9 +40,9 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
     >>> from dlordinal.losses import MCEAndWKLoss
     >>> num_classes = 5
     >>> loss = MCEAndWKLoss(num_classes, C=0.7, use_logits=True)
-    >>> y_pred = torch.randn(3, num_classes)
-    >>> y_true = torch.randint(0, num_classes, (3,))
-    >>> output = loss(y_true, y_pred)
+    >>> input = torch.randn(3, num_classes)
+    >>> target = torch.randint(0, num_classes, (3,))
+    >>> target = loss(input, target)
     """
 
     def __init__(
@@ -87,14 +87,14 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
         )
         self.mce = MCELoss(self.num_classes, weight=weight, use_logits=self.use_logits)
 
-    def forward(self, y_true: torch.Tensor, y_pred: torch.Tensor):
+    def forward(self, input: torch.Tensor, target: torch.Tensor):
         """
         Parameters
         ----------
-        y_true : torch.Tensor
+        input : torch.Tensor
             Ground truth labels of shape (N,) where N is the batch size. Values are
             class indices in the range [0, num_classes-1].
-        y_pred : torch.Tensor
+        target : torch.Tensor
             Predicted labels of shape (N, num_classes). If `use_logits` is True, these
             are logits. Otherwise, they are probabilities.
 
@@ -106,7 +106,7 @@ class MCEAndWKLoss(torch.nn.modules.loss._WeightedLoss):
             the per-class loss for both MCE and WK losses.
         """
 
-        wk_result = self.wk(y_pred, y_true)
-        mce_result = self.mce(y_pred, y_true)
+        wk_result = self.wk(input, target)
+        mce_result = self.mce(input, target)
 
         return self.C * wk_result + (1 - self.C) * mce_result

--- a/dlordinal/losses/tests/test_mcewkloss.py
+++ b/dlordinal/losses/tests/test_mcewkloss.py
@@ -39,8 +39,8 @@ def test_mcewkloss_basic(device):
     target = torch.tensor([2, 2, 1]).to(device)
 
     # Compute the loss
-    output = loss(target, torch.nn.functional.softmax(input_data, dim=1))
-    output_logits = loss_logits(target, input_data)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     # Verifies that the output is a tensor
     assert isinstance(output, torch.Tensor)
@@ -82,8 +82,8 @@ def test_mcewkloss_exactvalue(device):
     target = torch.tensor([0, 1, 2, 3, 4, 5, 4, 3, 2, 1]).to(device)
 
     # Compute the loss
-    output = loss(target, torch.nn.functional.softmax(input_data, dim=1))
-    output_logits = loss_logits(target, input_data)
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
+    output_logits = loss_logits(input_data, target)
 
     assert output.item() == pytest.approx(0.5304394960403442, rel=1e-3)
     assert output_logits.item() == pytest.approx(0.5304394960403442, rel=1e-3)
@@ -130,12 +130,12 @@ def test_mcewkloss_weights(device):
     target = torch.tensor([3, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(target, torch.nn.functional.softmax(input_data, dim=1))
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_weighted = loss_weighted(
-        target, torch.nn.functional.softmax(input_data, dim=1)
+        torch.nn.functional.softmax(input_data, dim=1), target
     )
-    output_logits = loss_logits(target, input_data)
-    output_logits_weighted = loss_logits_weighted(target, input_data)
+    output_logits = loss_logits(input_data, target)
+    output_logits_weighted = loss_logits_weighted(input_data, target)
 
     # The error should be lower when using the weighted version as the weight
     # of classes 1 and 3 is less than 1
@@ -146,12 +146,12 @@ def test_mcewkloss_weights(device):
     target = torch.tensor([5, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(target, torch.nn.functional.softmax(input_data, dim=1))
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_weighted = loss_weighted(
-        target, torch.nn.functional.softmax(input_data, dim=1)
+        torch.nn.functional.softmax(input_data, dim=1), target
     )
-    output_logits = loss_logits(target, input_data)
-    output_logits_weighted = loss_logits_weighted(target, input_data)
+    output_logits = loss_logits(input_data, target)
+    output_logits_weighted = loss_logits_weighted(input_data, target)
 
     # The error should be higher when using the weighted version as the weight
     # of class 5 is way higher than 1
@@ -190,12 +190,12 @@ def test_mcewkloss_combination(device):
     target = torch.tensor([3, 3, 1]).to(device)
 
     # Compute the loss
-    output = loss(target, torch.nn.functional.softmax(input_data, dim=1))
+    output = loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_mce = mce_loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_wk = wk_loss(torch.nn.functional.softmax(input_data, dim=1), target)
     output_combined = C * output_mce + (1 - C) * output_wk
 
-    output_logits = loss_logits(target, input_data)
+    output_logits = loss_logits(input_data, target)
     output_mce_logits = mce_loss_logits(input_data, target)
     output_wk_logits = wk_loss_logits(input_data, target)
     output_combined_logits = C * output_mce_logits + (1 - C) * output_wk_logits


### PR DESCRIPTION
- I have changed the order of the parameters of the forward method in MCEWKLoss to match the standard order in pytorch. 
- I also renamed the parameters to input and targets in the forward methods of MCEWKLoss and WKLoss. 
- The tests for MCEWKLoss have been updated accordingly.