### PR TITLE
BUG: Targets shape correction in hybrid dropout

### DIFF
--- a/dlordinal/dropout/hybrid_dropout.py
+++ b/dlordinal/dropout/hybrid_dropout.py
@@ -39,7 +39,10 @@ class HybridDropoutContainer(nn.Module):
         Parameters
         ----------
         targets : torch.Tensor
-            Targets of the batch
+            Targets of the batch. Must be a 1D tensor of shape (``batch_size``,)
+            containing integer class indices for each sample in the batch.
+            One-hot or soft label tensors of shape (``batch_size``, ``num_classes``) are
+            not supported.
 
         Example
         -------
@@ -125,6 +128,14 @@ class HybridDropout(nn.Module):
                 raise ValueError(
                     "Batch targets have not been set. Use"
                     " HybridDropoutContainer.set_targets() to set the targets."
+                )
+
+            if targets.ndim != 1:
+                raise ValueError(
+                    "Targets must be a 1D tensor"
+                    f" but got {targets.ndim}D tensor"
+                    "If you are using one-hot encoding or soft labels, (shape [batch_size, num_classes]),"
+                    " please convert them to class indices (shape [batch_size])"
                 )
 
             targets = torch.reshape(targets, (1, targets.shape[0]))

--- a/dlordinal/dropout/tests/test_hybrid_dropout.py
+++ b/dlordinal/dropout/tests/test_hybrid_dropout.py
@@ -62,6 +62,17 @@ def test_forward_with_targets(device):
     assert outputs.shape == (32, 5)
 
 
+def test_wrong_target_shape(hybrid_dropout_container, device):
+    inputs = torch.randn(32, 10).to(device)
+    targets = torch.randn(32, 5).to(device)  # Wrong shape
+
+    hybrid_dropout_container.set_targets(targets)
+
+    with pytest.raises(ValueError):
+        hybrid_dropout_container = hybrid_dropout_container.to(device)
+        hybrid_dropout_container(inputs)
+
+
 def test_forward_without_targets(hybrid_dropout_container, device):
     inputs = torch.randn(32, 10).to(device)
 


### PR DESCRIPTION
`hybrid_dropout.py` has been corrected in order to detect the dimensions of the targets. When the target dimension is not equal to 1 the dropout will raise an error specifying the expected shape. The expected shape is not [`batch_size`, `num_classes`], instead it will be just [`batch_size`]

Also `test_hybrid_dropout.py` has been improved to check this target shape