### PR TITLE
[TST] Fix HCI dataset tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,6 +37,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache HCI raw tar
+      uses: actions/cache@v4
+      with:
+        path: .cache/hci_data/HistoricalColor-ECCV2012-DecadeDatabase.tar
+        key: hci-tar-v1
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -62,6 +68,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache HCI raw tar
+      uses: actions/cache@v4
+      with:
+        path: .cache/hci_data/HistoricalColor-ECCV2012-DecadeDatabase.tar
+        key: hci-tar-v1
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -84,6 +96,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Cache HCI raw tar
+      uses: actions/cache@v4
+      with:
+        path: .cache/hci_data/HistoricalColor-ECCV2012-DecadeDatabase.tar
+        key: hci-tar-v1
 
     - name: Install dependencies
       run: |
@@ -114,6 +132,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Cache HCI raw tar
+      uses: actions/cache@v4
+      with:
+        path: .cache/hci_data/HistoricalColor-ECCV2012-DecadeDatabase.tar
+        key: hci-tar-v1
 
     - name: Install dependencies
       run: |

--- a/dlordinal/datasets/hci.py
+++ b/dlordinal/datasets/hci.py
@@ -7,7 +7,11 @@ import pandas as pd
 from PIL import Image, UnidentifiedImageError
 from torchvision.datasets import ImageFolder
 from torchvision.datasets.folder import IMG_EXTENSIONS, default_loader
-from torchvision.datasets.utils import download_and_extract_archive
+from torchvision.datasets.utils import (
+    check_integrity,
+    download_and_extract_archive,
+    extract_archive,
+)
 
 
 class HCI(ImageFolder):
@@ -90,8 +94,22 @@ class HCI(ImageFolder):
         if not target_folder.exists() or not self._verify_md5sums():
             if target_folder.exists():
                 rmtree(target_folder, ignore_errors=True)
-            # Download and extract
-            download_and_extract_archive(self.URL, self.root, md5=self.MD5)
+
+            if not (
+                self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"
+            ).exists() or not check_integrity(
+                str(self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"), self.MD5
+            ):
+                # Download and extract
+                download_and_extract_archive(self.URL, str(self.root), md5=self.MD5)
+            else:
+                # Extract from existing tar
+                extract_archive(
+                    str(self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"),
+                    str(self.root),
+                    False,
+                )
+
             extracted_folder = (
                 self.root
                 / "HistoricalColor-ECCV2012"

--- a/dlordinal/datasets/hci.py
+++ b/dlordinal/datasets/hci.py
@@ -52,6 +52,10 @@ class HCI(ImageFolder):
         MD5 checksum used to verify the downloaded archive.
     CATEGORIES : dict
         Mapping from decade names to numeric class labels (as strings).
+    base_root: Path
+        Base directory for dataset storage and processing.
+    train: bool
+        Indicates whether the dataset instance is for training or testing.
 
     Example
     -----
@@ -79,10 +83,11 @@ class HCI(ImageFolder):
         is_valid_file: Optional[Callable[[str], bool]] = None,
         train: bool = True,
     ):
-        self.root = Path(root)
+        self.base_root = Path(root)
+        self.train = train
         self._prepare_dataset()
         super().__init__(
-            root=self.root / "HCI" / ("train" if train else "test"),
+            root=str(self.base_root / "HCI" / ("train" if self.train else "test")),
             loader=default_loader,
             transform=transform,
             target_transform=target_transform,
@@ -90,35 +95,35 @@ class HCI(ImageFolder):
         )
 
     def _prepare_dataset(self) -> bool:
-        target_folder = self.root / "HCI"
+        target_folder = self.base_root / "HCI"
         if not target_folder.exists() or not self._verify_md5sums():
             if target_folder.exists():
                 rmtree(target_folder, ignore_errors=True)
 
-            if not (
-                self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"
-            ).exists() or not check_integrity(
-                str(self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"), self.MD5
-            ):
+            tar_path = self.base_root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"
+
+            if not tar_path.exists() or not check_integrity(str(tar_path), self.MD5):
                 # Download and extract
-                download_and_extract_archive(self.URL, str(self.root), md5=self.MD5)
+                download_and_extract_archive(
+                    self.URL, str(self.base_root), md5=self.MD5
+                )
             else:
                 # Extract from existing tar
                 extract_archive(
-                    str(self.root / "HistoricalColor-ECCV2012-DecadeDatabase.tar"),
-                    str(self.root),
+                    str(tar_path),
+                    str(self.base_root),
                     False,
                 )
 
             extracted_folder = (
-                self.root
+                self.base_root
                 / "HistoricalColor-ECCV2012"
                 / "data"
                 / "imgs"
                 / "decade_database"
             )
             extracted_folder.rename(target_folder)
-            rmtree(self.root / "HistoricalColor-ECCV2012", ignore_errors=True)
+            rmtree(self.base_root / "HistoricalColor-ECCV2012", ignore_errors=True)
 
             # Rename categories
             for old_name, new_name in self.CATEGORIES.items():
@@ -133,8 +138,8 @@ class HCI(ImageFolder):
                             with Image.open(img_path) as img:
                                 img = img.resize((224, 224), Image.Resampling.LANCZOS)
                                 img.save(img_path)
-                        except UnidentifiedImageError as e:
-                            print(f"Removing corrupted image: {img_path} ({e})")
+                        except UnidentifiedImageError:
+                            # print(f"Removing corrupted image: {img_path} ({e})")
                             img_path.unlink()
 
             # Train/test split
@@ -175,23 +180,23 @@ class HCI(ImageFolder):
                 cat_folder.rmdir()
 
     def _create_md5sums_file(self):
-        md5sum_path = self.root / "HCI" / "md5sums.txt"
+        md5sum_path = self.base_root / "HCI" / "md5sums.txt"
         with open(md5sum_path, "w") as f:
-            for img_path in (self.root / "HCI").rglob("*"):
+            for img_path in (self.base_root / "HCI").rglob("*"):
                 if img_path.suffix.lower() in IMG_EXTENSIONS:
                     with open(img_path, "rb") as img_file:
                         file_hash = md5(img_file.read()).hexdigest()
-                    relative_path = img_path.relative_to(self.root / "HCI")
+                    relative_path = img_path.relative_to(self.base_root / "HCI")
                     f.write(f"{file_hash} {relative_path}\n")
 
     def _verify_md5sums(self) -> bool:
-        md5sum_path = self.root / "HCI" / "md5sums.txt"
+        md5sum_path = self.base_root / "HCI" / "md5sums.txt"
         if not md5sum_path.exists():
             return False
         with open(md5sum_path, "r") as f:
             for line in f:
                 expected_hash, relative_path = line.strip().split(" ", 1)
-                img_path = self.root / "HCI" / relative_path
+                img_path = self.base_root / "HCI" / relative_path
                 if not img_path.exists():
                     return False
                 with open(img_path, "rb") as img_file:

--- a/dlordinal/datasets/tests/test_hci.py
+++ b/dlordinal/datasets/tests/test_hci.py
@@ -7,7 +7,7 @@ from dlordinal.datasets import HCI
 
 
 def test_hci_basic(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -19,7 +19,7 @@ def test_hci_basic(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -29,7 +29,7 @@ def test_hci_basic(tmp_path):
 
 
 def test_hci_prepare_again(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci = HCI(
                 root=tmp_path,
@@ -37,7 +37,7 @@ def test_hci_prepare_again(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -48,7 +48,7 @@ def test_hci_prepare_again(tmp_path):
 
 
 def test_hci_categories(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -60,7 +60,7 @@ def test_hci_categories(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -77,7 +77,7 @@ def test_hci_categories(tmp_path):
 
 
 def test_hci_image_size(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -89,7 +89,7 @@ def test_hci_image_size(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -101,7 +101,7 @@ def test_hci_image_size(tmp_path):
 
 
 def test_hci_md5_verification(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -113,7 +113,7 @@ def test_hci_md5_verification(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -131,7 +131,7 @@ def test_hci_md5_verification(tmp_path):
 
 
 def test_hci_prepare_after_corruption(tmp_path):
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -143,7 +143,7 @@ def test_hci_prepare_after_corruption(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e
@@ -175,7 +175,7 @@ def test_hci_prepare_after_corruption(tmp_path):
 def test_hci_load_data_with_dataloader(tmp_path):
     from torch.utils.data import DataLoader
 
-    for i in range(3):
+    for i in range(5):
         try:
             hci_train = HCI(
                 root=tmp_path,
@@ -189,7 +189,7 @@ def test_hci_load_data_with_dataloader(tmp_path):
             )
             break
         except URLError as e:
-            time.sleep(5 * (i + 1))
+            time.sleep(10 * (i + 1))
 
             if i == 2:
                 raise e

--- a/dlordinal/datasets/tests/test_hci.py
+++ b/dlordinal/datasets/tests/test_hci.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import pytest
 from torchvision.transforms import ToTensor
@@ -48,6 +49,18 @@ def test_hci_categories(hci_train, hci_test):
     assert test_categories == {0, 1, 2, 3, 4}
 
 
+def test_hci_categories_count(hci_train, hci_test):
+    train_category_counts = {0: 186, 1: 186, 2: 186, 3: 186, 4: 186}
+    for _, label in hci_train:
+        train_category_counts[label] += 1
+    assert all(count > 0 for count in train_category_counts.values())
+
+    test_category_counts = {0: 79, 1: 79, 2: 79, 3: 79, 4: 79}
+    for _, label in hci_test:
+        test_category_counts[label] += 1
+    assert all(count > 0 for count in test_category_counts.values())
+
+
 def test_hci_image_size(hci_train, hci_test):
     for img, _ in hci_train:
         assert img.shape == (3, 224, 224)
@@ -72,7 +85,7 @@ def test_hci_md5_verification(base_path, tmp_path):
 
     # Modify one file to test MD5 verification
     sample_img_path = (
-        mutable_hci_train.root / "0" / next(iter(mutable_hci_train.samples))[0]
+        Path(mutable_hci_train.root) / "0" / next(iter(mutable_hci_train.samples))[0]
     )
     with open(sample_img_path, "rb+") as f:
         content = f.read()
@@ -82,7 +95,7 @@ def test_hci_md5_verification(base_path, tmp_path):
     assert not mutable_hci_test._verify_md5sums()
 
 
-def test_hci_prepare_after_corruption(base_path, tmp_path):
+def test_hci_prepare_after_corruption(base_path, tmp_path, hci_train, hci_test):
     dst = tmp_path / "hci"
     shutil.copytree(base_path, dst, dirs_exist_ok=True)
     mutable_hci_train = HCI(
@@ -99,7 +112,7 @@ def test_hci_prepare_after_corruption(base_path, tmp_path):
 
     # Modify one file to test re-preparation
     sample_train_img_path = (
-        mutable_hci_train.root / "0" / next(iter(mutable_hci_train.samples))[0]
+        Path(mutable_hci_train.root) / "0" / next(iter(mutable_hci_train.samples))[0]
     )
     with open(sample_train_img_path, "rb+") as f:
         content = f.read()
@@ -109,7 +122,7 @@ def test_hci_prepare_after_corruption(base_path, tmp_path):
     assert not mutable_hci_test._verify_md5sums()
 
     sample_test_img_path = (
-        mutable_hci_test.root / "0" / next(iter(mutable_hci_test.samples))[0]
+        Path(mutable_hci_test.root) / "0" / next(iter(mutable_hci_test.samples))[0]
     )
     with open(sample_test_img_path, "rb+") as f:
         content = f.read()
@@ -121,7 +134,7 @@ def test_hci_prepare_after_corruption(base_path, tmp_path):
     # Re-prepare dataset
     assert mutable_hci_train._prepare_dataset()
     assert mutable_hci_train._verify_md5sums()
-    assert mutable_hci_test._prepare_dataset()
+    # Test set is also repaired since they share the same base directory
     assert mutable_hci_test._verify_md5sums()
 
 

--- a/dlordinal/datasets/tests/test_hci.py
+++ b/dlordinal/datasets/tests/test_hci.py
@@ -1,26 +1,46 @@
+import time
+from urllib.error import URLError
+
 from torchvision.transforms import ToTensor
 
 from dlordinal.datasets import HCI
 
 
 def test_hci_basic(tmp_path):
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
+
     assert len(hci_train) > 0
     assert len(hci_test) > 0
 
 
 def test_hci_prepare_again(tmp_path):
-    hci = HCI(
-        root=tmp_path,
-        train=True,
-    )
+    for i in range(3):
+        try:
+            hci = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
     prepared_first = hci._prepare_dataset()
     prepared_second = hci._prepare_dataset()
     assert prepared_first is True
@@ -28,14 +48,23 @@ def test_hci_prepare_again(tmp_path):
 
 
 def test_hci_categories(tmp_path):
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
+
     train_categories = set()
     for _, label in hci_train:
         train_categories.add(label)
@@ -48,14 +77,23 @@ def test_hci_categories(tmp_path):
 
 
 def test_hci_image_size(tmp_path):
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
+
     for img, _ in hci_train:
         assert img.size == (224, 224)
     for img, _ in hci_test:
@@ -63,14 +101,23 @@ def test_hci_image_size(tmp_path):
 
 
 def test_hci_md5_verification(tmp_path):
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
+
     # Modify one file to test MD5 verification
     sample_img_path = hci_train.root / "0" / next(iter(hci_train.samples))[0]
     with open(sample_img_path, "rb+") as f:
@@ -84,14 +131,23 @@ def test_hci_md5_verification(tmp_path):
 
 
 def test_hci_prepare_after_corruption(tmp_path):
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
+
     # Modify one file to test re-preparation
     sample_train_img_path = hci_train.root / "0" / next(iter(hci_train.samples))[0]
     with open(sample_train_img_path, "rb+") as f:
@@ -119,16 +175,24 @@ def test_hci_prepare_after_corruption(tmp_path):
 def test_hci_load_data_with_dataloader(tmp_path):
     from torch.utils.data import DataLoader
 
-    hci_train = HCI(
-        root=tmp_path,
-        train=True,
-        transform=ToTensor(),
-    )
-    hci_test = HCI(
-        root=tmp_path,
-        train=False,
-        transform=ToTensor(),
-    )
+    for i in range(3):
+        try:
+            hci_train = HCI(
+                root=tmp_path,
+                train=True,
+                transform=ToTensor(),
+            )
+            hci_test = HCI(
+                root=tmp_path,
+                train=False,
+                transform=ToTensor(),
+            )
+            break
+        except URLError as e:
+            time.sleep(5 * (i + 1))
+
+            if i == 2:
+                raise e
 
     train_loader = DataLoader(hci_train, batch_size=32, shuffle=True)
     test_loader = DataLoader(hci_test, batch_size=32, shuffle=False)

--- a/dlordinal/datasets/tests/test_hci.py
+++ b/dlordinal/datasets/tests/test_hci.py
@@ -1,70 +1,42 @@
-import time
-from urllib.error import URLError
+import shutil
 
+import pytest
 from torchvision.transforms import ToTensor
 
 from dlordinal.datasets import HCI
 
 
-def test_hci_basic(tmp_path):
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
+@pytest.fixture(scope="session")
+def base_path():
+    return ".cache/hci_data"
 
-            if i == 2:
-                raise e
 
+@pytest.fixture(scope="session")
+def hci_train(base_path):
+    hci_train = HCI(
+        root=base_path,
+        train=True,
+        transform=ToTensor(),
+    )
+    return hci_train
+
+
+@pytest.fixture(scope="session")
+def hci_test(base_path):
+    hci_test = HCI(
+        root=base_path,
+        train=False,
+        transform=ToTensor(),
+    )
+    return hci_test
+
+
+def test_hci_basic(hci_train, hci_test):
     assert len(hci_train) > 0
     assert len(hci_test) > 0
 
 
-def test_hci_prepare_again(tmp_path):
-    for i in range(5):
-        try:
-            hci = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
-
-            if i == 2:
-                raise e
-    prepared_first = hci._prepare_dataset()
-    prepared_second = hci._prepare_dataset()
-    assert prepared_first is True
-    assert prepared_second is False
-
-
-def test_hci_categories(tmp_path):
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
-
-            if i == 2:
-                raise e
-
+def test_hci_categories(hci_train, hci_test):
     train_categories = set()
     for _, label in hci_train:
         train_categories.add(label)
@@ -76,123 +48,85 @@ def test_hci_categories(tmp_path):
     assert test_categories == {0, 1, 2, 3, 4}
 
 
-def test_hci_image_size(tmp_path):
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
-
-            if i == 2:
-                raise e
-
+def test_hci_image_size(hci_train, hci_test):
     for img, _ in hci_train:
-        assert img.size == (224, 224)
+        assert img.shape == (3, 224, 224)
     for img, _ in hci_test:
-        assert img.size == (224, 224)
+        assert img.shape == (3, 224, 224)
 
 
-def test_hci_md5_verification(tmp_path):
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
+def test_hci_md5_verification(base_path, tmp_path):
+    dst = tmp_path / "hci"
+    shutil.copytree(base_path, dst, dirs_exist_ok=True)
+    mutable_hci_train = HCI(
+        root=dst,
+        train=True,
+        transform=ToTensor(),
+    )
 
-            if i == 2:
-                raise e
+    mutable_hci_test = HCI(
+        root=dst,
+        train=False,
+        transform=ToTensor(),
+    )
 
     # Modify one file to test MD5 verification
-    sample_img_path = hci_train.root / "0" / next(iter(hci_train.samples))[0]
+    sample_img_path = (
+        mutable_hci_train.root / "0" / next(iter(mutable_hci_train.samples))[0]
+    )
     with open(sample_img_path, "rb+") as f:
         content = f.read()
         f.seek(0)
         f.write(b"corrupted_data" + content)
-    assert not hci_train._verify_md5sums()
-
-    # HCI test should also fail since it checks the whole dataset
-    assert not hci_test._verify_md5sums()
+    assert not mutable_hci_train._verify_md5sums()
+    assert not mutable_hci_test._verify_md5sums()
 
 
-def test_hci_prepare_after_corruption(tmp_path):
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
+def test_hci_prepare_after_corruption(base_path, tmp_path):
+    dst = tmp_path / "hci"
+    shutil.copytree(base_path, dst, dirs_exist_ok=True)
+    mutable_hci_train = HCI(
+        root=dst,
+        train=True,
+        transform=ToTensor(),
+    )
 
-            if i == 2:
-                raise e
+    mutable_hci_test = HCI(
+        root=dst,
+        train=False,
+        transform=ToTensor(),
+    )
 
     # Modify one file to test re-preparation
-    sample_train_img_path = hci_train.root / "0" / next(iter(hci_train.samples))[0]
+    sample_train_img_path = (
+        mutable_hci_train.root / "0" / next(iter(mutable_hci_train.samples))[0]
+    )
     with open(sample_train_img_path, "rb+") as f:
         content = f.read()
         f.seek(0)
         f.write(b"corrupted_data" + content)
-    assert not hci_train._verify_md5sums()
-    assert not hci_test._verify_md5sums()
+    assert not mutable_hci_train._verify_md5sums()
+    assert not mutable_hci_test._verify_md5sums()
 
-    sample_test_img_path = hci_test.root / "0" / next(iter(hci_test.samples))[0]
+    sample_test_img_path = (
+        mutable_hci_test.root / "0" / next(iter(mutable_hci_test.samples))[0]
+    )
     with open(sample_test_img_path, "rb+") as f:
         content = f.read()
         f.seek(0)
         f.write(b"corrupted_data" + content)
-    assert not hci_train._verify_md5sums()
-    assert not hci_test._verify_md5sums()
+    assert not mutable_hci_train._verify_md5sums()
+    assert not mutable_hci_test._verify_md5sums()
 
     # Re-prepare dataset
-    assert hci_train._prepare_dataset()
-    assert hci_train._verify_md5sums()
-    assert hci_test._prepare_dataset()
-    assert hci_test._verify_md5sums()
+    assert mutable_hci_train._prepare_dataset()
+    assert mutable_hci_train._verify_md5sums()
+    assert mutable_hci_test._prepare_dataset()
+    assert mutable_hci_test._verify_md5sums()
 
 
-def test_hci_load_data_with_dataloader(tmp_path):
+def test_hci_load_data_with_dataloader(hci_train, hci_test):
     from torch.utils.data import DataLoader
-
-    for i in range(5):
-        try:
-            hci_train = HCI(
-                root=tmp_path,
-                train=True,
-                transform=ToTensor(),
-            )
-            hci_test = HCI(
-                root=tmp_path,
-                train=False,
-                transform=ToTensor(),
-            )
-            break
-        except URLError as e:
-            time.sleep(10 * (i + 1))
-
-            if i == 2:
-                raise e
 
     train_loader = DataLoader(hci_train, batch_size=32, shuffle=True)
     test_loader = DataLoader(hci_test, batch_size=32, shuffle=False)


### PR DESCRIPTION
HCI dataset tests intermittently fail in GitHub Actions with:
```
urllib.error.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>
```

This does not happen locally and is likely due to transient network issues or limitations in the CI environment, especially when multiple tests trigger dataset downloads in parallel.

~~I have added a retry mechanism when instantiating the dataset in tests:~~

- ~~Retry up to 5 times on `URLError`~~
- ~~Apply a small backoff between attempts~~
- ~~Re-raise the exception if all attempts fail~~

**Update:**
Since the retry mechanism did not resolve the issue, a new approach was implemented:

- The dataset preparation logic was modified to reuse the existing `.tar` file when its MD5 checksum is valid. If the extracted dataset directory is missing but the `.tar` file is present and valid, the dataset is reconstructed by extraction only, avoiding a new download. This reduces the number of network requests, but was still not sufficient to fully stabilise CI runs.

- To address this, caching was introduced in the GitHub Actions workflow for the `.tar` file. As long as the cached archive remains valid, it is reused across runs, effectively eliminating redundant downloads in most cases.