### PR TITLE
[TST] Added global device fixture and fixed gpu tests workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -47,6 +47,8 @@ jobs:
 
   pytest-gpu:
     runs-on: [gpu]
+    env:
+      PYTEST_CUDA_ONLY: "1"
 
     strategy:
       fail-fast: false

--- a/dlordinal/conftest.py
+++ b/dlordinal/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+import torch
+
+
+@pytest.fixture(params=["cpu", "cuda"])
+def device(request):
+    cuda_only = os.getenv("PYTEST_CUDA_ONLY", "0") == "1"
+
+    dev = request.param
+
+    # CI GPU mode → skip CPU tests
+    if cuda_only and dev != "cuda":
+        pytest.skip("Skipping CPU tests in CUDA-only CI mode")
+
+    if dev == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    return torch.device(dev)

--- a/dlordinal/dropout/tests/test_hybrid_dropout.py
+++ b/dlordinal/dropout/tests/test_hybrid_dropout.py
@@ -20,11 +20,6 @@ class ModelWithHybridDropout(nn.Module):
 
 
 @pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
 def model():
     return ModelWithHybridDropout()
 

--- a/dlordinal/losses/tests/test_beta_loss.py
+++ b/dlordinal/losses/tests/test_beta_loss.py
@@ -5,16 +5,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import BetaLoss
 
 
-@pytest.fixture
-def device():
-    d = "cpu"
-
-    if torch.cuda.is_available():
-        d = "cuda"
-
-    return d
-
-
 def test_beta_loss_creation(device):
     base_loss = CrossEntropyLoss().to(device)
     loss = BetaLoss(base_loss=base_loss, num_classes=5).to(device)

--- a/dlordinal/losses/tests/test_binomial_loss.py
+++ b/dlordinal/losses/tests/test_binomial_loss.py
@@ -5,11 +5,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import BinomialLoss
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_binomial_loss_creation(device):
     base_loss = CrossEntropyLoss().to(device)
     loss = BinomialLoss(base_loss=base_loss, num_classes=5).to(device)

--- a/dlordinal/losses/tests/test_cdw.py
+++ b/dlordinal/losses/tests/test_cdw.py
@@ -6,11 +6,6 @@ from torch import nn
 from dlordinal.losses import CDWCELoss
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def cdwce_loop_softmax(y_pred, y_true, alpha, device):
     y_pred = nn.functional.softmax(y_pred, dim=1).to(device)
     y_true = y_true.to(device)

--- a/dlordinal/losses/tests/test_corn_loss.py
+++ b/dlordinal/losses/tests/test_corn_loss.py
@@ -19,21 +19,6 @@ def num_classes():
     return 5
 
 
-@pytest.fixture(
-    params=[
-        "cpu",
-        pytest.param(
-            "cuda",
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available(), reason="CUDA not available"
-            ),
-        ),
-    ]
-)
-def device(request):
-    return torch.device(request.param)
-
-
 def test_cornloss_creation(device):
     """
     Tests successful initialization of CORNLoss, ensuring the correct number

--- a/dlordinal/losses/tests/test_custom_loss.py
+++ b/dlordinal/losses/tests/test_custom_loss.py
@@ -1,13 +1,7 @@
-import pytest
 import torch
 from torch.nn import CrossEntropyLoss
 
 from dlordinal.losses import CustomTargetsLoss
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 # Auxiliar function to get a test class

--- a/dlordinal/losses/tests/test_emd_loss.py
+++ b/dlordinal/losses/tests/test_emd_loss.py
@@ -5,11 +5,6 @@ from dlordinal.losses import EMDLoss
 from dlordinal.metrics import ranked_probability_score
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_emd_loss_creation(device):
     loss = EMDLoss(num_classes=5).to(device)
     assert isinstance(loss, EMDLoss)

--- a/dlordinal/losses/tests/test_exponential_loss.py
+++ b/dlordinal/losses/tests/test_exponential_loss.py
@@ -5,11 +5,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import ExponentialLoss
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_exponential_loss_creation(device):
     base_loss = CrossEntropyLoss().to(device)
     loss = ExponentialLoss(base_loss=base_loss, num_classes=5).to(device)

--- a/dlordinal/losses/tests/test_general_triangular_loss.py
+++ b/dlordinal/losses/tests/test_general_triangular_loss.py
@@ -6,11 +6,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import GeneralTriangularLoss
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_general_triangular_loss_creation(device):
     # Generate 12 random values between 0.01 and 0.2
     alphas = np.array(

--- a/dlordinal/losses/tests/test_geometric_cce_loss.py
+++ b/dlordinal/losses/tests/test_geometric_cce_loss.py
@@ -7,11 +7,6 @@ from dlordinal.losses import GeometricCrossEntropyLoss
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_geometric_loss_creation(device):
     loss = GeometricCrossEntropyLoss(num_classes=5).to(device)
     assert isinstance(loss, GeometricCrossEntropyLoss)

--- a/dlordinal/losses/tests/test_mceloss.py
+++ b/dlordinal/losses/tests/test_mceloss.py
@@ -4,11 +4,6 @@ import torch
 from dlordinal.losses import MCELoss
 
 
-@pytest.fixture
-def device():
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-
 def test_mceloss_creation(device):
     loss = MCELoss(num_classes=6).to(device)
     loss_logits = MCELoss(num_classes=6, use_logits=True).to(device)

--- a/dlordinal/losses/tests/test_mcewkloss.py
+++ b/dlordinal/losses/tests/test_mcewkloss.py
@@ -4,11 +4,6 @@ import torch
 from dlordinal.losses import MCEAndWKLoss, MCELoss, WKLoss
 
 
-@pytest.fixture
-def device():
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-
 def test_mcewkloss_creation(device):
     loss = MCEAndWKLoss(num_classes=6).to(device)
     loss_logits = MCEAndWKLoss(num_classes=6, use_logits=True).to(device)

--- a/dlordinal/losses/tests/test_ordinal_ecoc_loss.py
+++ b/dlordinal/losses/tests/test_ordinal_ecoc_loss.py
@@ -1,12 +1,6 @@
-import pytest
 import torch
 
 from dlordinal.losses import OrdinalECOCDistanceLoss
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def test_ordinal_ecoc_distance_loss_creation(device):

--- a/dlordinal/losses/tests/test_poisson_loss.py
+++ b/dlordinal/losses/tests/test_poisson_loss.py
@@ -5,11 +5,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import PoissonLoss
 
 
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
 def test_poisson_loss_creation(device):
     base_loss = CrossEntropyLoss().to(device)
     loss = PoissonLoss(base_loss=base_loss, num_classes=5).to(device)

--- a/dlordinal/losses/tests/test_triangular_loss.py
+++ b/dlordinal/losses/tests/test_triangular_loss.py
@@ -5,12 +5,6 @@ from torch.nn import CrossEntropyLoss
 from dlordinal.losses import TriangularLoss
 
 
-@pytest.fixture
-def device():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    return device
-
-
 def test_triangular_loss_creation(device):
     base_loss = CrossEntropyLoss().to(device)
     loss = TriangularLoss(base_loss=base_loss, num_classes=5).to(device)

--- a/dlordinal/losses/tests/test_wkloss.py
+++ b/dlordinal/losses/tests/test_wkloss.py
@@ -4,11 +4,6 @@ import torch
 from dlordinal.losses import WKLoss
 
 
-@pytest.fixture
-def device():
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-
 def test_wkloss_creation(device):
     loss = WKLoss(num_classes=6).to(device)
     assert isinstance(loss, WKLoss)

--- a/dlordinal/output_layers/tests/test_clm.py
+++ b/dlordinal/output_layers/tests/test_clm.py
@@ -1,13 +1,7 @@
 import numpy as np
-import pytest
 import torch
 
 from dlordinal.output_layers import CLM
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def _test_probas(clm, device):

--- a/dlordinal/output_layers/tests/test_copoc.py
+++ b/dlordinal/output_layers/tests/test_copoc.py
@@ -1,12 +1,6 @@
-import pytest
 import torch
 
 from dlordinal.output_layers import COPOC
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def _is_unimodal(probs: torch.Tensor) -> bool:

--- a/dlordinal/output_layers/tests/test_ordinal_fully_connected.py
+++ b/dlordinal/output_layers/tests/test_ordinal_fully_connected.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 from torch import nn
 
@@ -6,11 +5,6 @@ from dlordinal.output_layers import (
     ResNetOrdinalFullyConnected,
     VGGOrdinalFullyConnected,
 )
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def test_ordinal_resnet_fc_creation(device):

--- a/dlordinal/output_layers/tests/test_stick_breaking_layer.py
+++ b/dlordinal/output_layers/tests/test_stick_breaking_layer.py
@@ -1,12 +1,6 @@
-import pytest
 import torch
 
 from dlordinal.output_layers import StickBreakingLayer
-
-
-@pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 def test_stick_breaking_layer_creation(device):

--- a/dlordinal/wrappers/tests/test_obdecoc.py
+++ b/dlordinal/wrappers/tests/test_obdecoc.py
@@ -6,11 +6,6 @@ from dlordinal.wrappers import OBDECOCModel
 
 
 @pytest.fixture
-def device():
-    return "cuda" if torch.cuda.is_available() else "cpu"
-
-
-@pytest.fixture
 def sample_tensor():
     return torch.randn(1, 3, 224, 224)
 


### PR DESCRIPTION
I have added the following global fixture in `dlordinal/conftest.py` to make it available across all tests:

```python
@pytest.fixture(params=["cpu", "cuda"])
def device(request):
    cuda_only = os.getenv("PYTEST_CUDA_ONLY", "0") == "1"

    dev = request.param

    # CI GPU mode → skip CPU tests
    if cuda_only and dev != "cuda":
        pytest.skip("Skipping CPU tests in CUDA-only CI mode")

    if dev == "cuda" and not torch.cuda.is_available():
        pytest.skip("CUDA not available")

    return torch.device(dev)
```

It also allows skipping CPU tests using the `PYTEST_CUDA_ONLY` environment variable.

Additionally, I updated the GPU GitHub Actions workflow to avoid running CPU tests on our GPU runner, since they are already executed on GitHub’s standard runner.