### PR TITLE
[TST] Added no_gpu_ci pytest marker

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,7 +82,7 @@ jobs:
         pip install .[dev]
 
     - name: Run tests
-      run: python -m pytest -n 10
+      run: python -m pytest -n auto -m "not no_gpu_ci"
 
   tests-codecov:
     runs-on: ubuntu-22.04

--- a/dlordinal/datasets/tests/test_adience.py
+++ b/dlordinal/datasets/tests/test_adience.py
@@ -231,6 +231,7 @@ def adience_test(tmp_path):
     return get_adience_instance(tmp_path, train=False, verbose=False)
 
 
+@pytest.mark.no_gpu_ci
 def test_adience_init(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         assert adience._check_if_extracted()
@@ -239,6 +240,7 @@ def test_adience_init(adience_train, adience_test):
         assert adience._check_input_files()
 
 
+@pytest.mark.no_gpu_ci
 def test_adience_len(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         assert len(adience) == len(adience.targets)
@@ -250,6 +252,7 @@ def test_adience_len(adience_train, adience_test):
             len(adience)
 
 
+@pytest.mark.no_gpu_ci
 def test_adience_getitem(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         for i in range(len(adience)):
@@ -273,6 +276,7 @@ def test_adience_getitem(adience_train, adience_test):
             assert np.array_equal(adience[i][1], adience.targets[i])
 
 
+@pytest.mark.no_gpu_ci
 def test_assign_range_integers(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         assert adience._assign_range("1") == 0
@@ -286,6 +290,7 @@ def test_assign_range_integers(adience_train, adience_test):
         assert adience._assign_range("101") is None
 
 
+@pytest.mark.no_gpu_ci
 def test_assing_range_tuples(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         assert adience._assign_range("(0, 2)") == 0
@@ -298,11 +303,13 @@ def test_assing_range_tuples(adience_train, adience_test):
         assert adience._assign_range("(60, 100)") == 7
 
 
+@pytest.mark.no_gpu_ci
 def test_assign_range_none(adience_train, adience_test):
     for adience in [adience_train, adience_test]:
         assert adience._assign_range("None") is None
 
 
+@pytest.mark.no_gpu_ci
 def test_adience_train_test(adience_train, adience_test):
     assert len(adience_train) != len(adience_test)
 
@@ -312,12 +319,14 @@ def test_adience_train_test(adience_train, adience_test):
     assert train_labels != test_labels
 
 
+@pytest.mark.no_gpu_ci
 def test_image_path_from_row():
     row = {"user_id": "123", "face_id": "456", "original_image": "image.jpg"}
     path = _image_path_from_row(row)
     assert path == "123/landmark_aligned_face.456.image.jpg"
 
 
+@pytest.mark.no_gpu_ci
 def test_track_progress():
     tar_file_path = "fake.tar.gz"
 
@@ -330,6 +339,7 @@ def test_track_progress():
         os.remove(tar_file_path)
 
 
+@pytest.mark.no_gpu_ci
 def test_process_and_split(monkeypatch, tmp_path):
     mock_image_open = Mock(side_effect=lambda _: Image.new("RGB", (128, 128)))
     monkeypatch.setattr("PIL.Image.open", mock_image_open)
@@ -384,12 +394,14 @@ def test_process_and_split(monkeypatch, tmp_path):
         assert mock_symlink_to.call_count == initial_symlink_count
 
 
+@pytest.mark.no_gpu_ci
 def test_adience_classes(adience_train, adience_test):
     assert adience_train.classes == adience_test.classes
     assert adience_train.classes == np.unique(adience_train.targets).tolist()
     assert adience_test.classes == np.unique(adience_test.targets).tolist()
 
 
+@pytest.mark.no_gpu_ci
 def test_check_input_files(adience_train, adience_test, tmp_path):
     assert adience_train._check_input_files()
     assert adience_test._check_input_files()
@@ -404,6 +416,7 @@ def test_check_input_files(adience_train, adience_test, tmp_path):
         Adience(root=Path(tmp_path) / "test", train=True)
 
 
+@pytest.mark.no_gpu_ci
 def test_check_if_extracted(adience_train, adience_test):
     assert adience_train._check_if_extracted()
     assert adience_test._check_if_extracted()
@@ -413,6 +426,7 @@ def test_check_if_extracted(adience_train, adience_test):
     assert not adience_test._check_if_extracted()
 
 
+@pytest.mark.no_gpu_ci
 def test_check_if_transformed(adience_train, adience_test):
     assert adience_train._check_if_transformed()
     assert adience_test._check_if_transformed()
@@ -422,6 +436,7 @@ def test_check_if_transformed(adience_train, adience_test):
     assert not adience_test._check_if_transformed()
 
 
+@pytest.mark.no_gpu_ci
 def test_check_if_partitioned(adience_train, adience_test):
     assert adience_train._check_if_partitioned()
     assert adience_test._check_if_partitioned()
@@ -432,6 +447,7 @@ def test_check_if_partitioned(adience_train, adience_test):
     assert not adience_test._check_if_partitioned()
 
 
+@pytest.mark.no_gpu_ci
 def test_extract_data(adience_train, adience_test):
     assert adience_train._check_if_extracted()
     assert adience_test._check_if_extracted()

--- a/dlordinal/datasets/tests/test_featuredataset.py
+++ b/dlordinal/datasets/tests/test_featuredataset.py
@@ -18,11 +18,13 @@ def sample_data(tmp_path):
     return csv_path
 
 
+@pytest.mark.no_gpu_ci
 def test_feature_dataset_creation(sample_data):
     dataset = FeatureDataset(sample_data)
     assert isinstance(dataset, FeatureDataset)
 
 
+@pytest.mark.no_gpu_ci
 def test_feature_dataset(sample_data):
     dataset = FeatureDataset(sample_data)
 

--- a/dlordinal/datasets/tests/test_fgnet.py
+++ b/dlordinal/datasets/tests/test_fgnet.py
@@ -27,11 +27,13 @@ def fgnet_test(tmp_path):
     return fgnet
 
 
+@pytest.mark.no_gpu_ci
 def test_download(fgnet_train):
     fgnet_train.download()
     assert fgnet_train._check_integrity_download()
 
 
+@pytest.mark.no_gpu_ci
 def test_process(fgnet_train):
     fgnet_train.process(
         fgnet_train.root / "FGNET/images",
@@ -40,6 +42,7 @@ def test_process(fgnet_train):
     assert fgnet_train._check_integrity_process()
 
 
+@pytest.mark.no_gpu_ci
 def test_split(fgnet_train):
     fgnet_train.split(
         fgnet_train.root / "FGNET/data_processed/fgnet.csv",
@@ -52,6 +55,7 @@ def test_split(fgnet_train):
     assert fgnet_train._check_integrity_split()
 
 
+@pytest.mark.no_gpu_ci
 def test_find_category(fgnet_train):
     assert fgnet_train.find_category(1) == 0
     assert fgnet_train.find_category(9) == 1
@@ -60,22 +64,26 @@ def test_find_category(fgnet_train):
     assert fgnet_train.find_category(33) == 4
 
 
+@pytest.mark.no_gpu_ci
 def test_get_age_from_filename(fgnet_train):
     filename = "001A12X_X.jpg"
     assert fgnet_train.get_age_from_filename(filename) == 12
 
 
+@pytest.mark.no_gpu_ci
 def test_load_data(fgnet_train):
     data = fgnet_train.load_data(fgnet_train.root / "FGNET/images")
     assert len(data) > 0
 
 
+@pytest.mark.no_gpu_ci
 def test_process_images_from_df(fgnet_train):
     data = fgnet_train.load_data(fgnet_train.root / "FGNET/images")
     processed_images = list((fgnet_train.root / "FGNET/data_processed").rglob("*.JPG"))
     assert len(processed_images) == len(data)
 
 
+@pytest.mark.no_gpu_ci
 def test_split_dataframe(fgnet_train):
     csv_path = fgnet_train.root / "FGNET/data_processed/fgnet.csv"
     train_images_path = fgnet_train.root / "FGNET/train"
@@ -88,6 +96,7 @@ def test_split_dataframe(fgnet_train):
     assert len(test_df) > 0
 
 
+@pytest.mark.no_gpu_ci
 def test_getitem(fgnet_train, fgnet_test):
     for fgnet in [fgnet_train, fgnet_test]:
         for i in range(len(fgnet)):
@@ -111,12 +120,14 @@ def test_getitem(fgnet_train, fgnet_test):
             assert np.array_equal(fgnet[i][1], fgnet.targets[i])
 
 
+@pytest.mark.no_gpu_ci
 def test_len(fgnet_train, fgnet_test):
     for fgnet in [fgnet_train, fgnet_test]:
         assert len(fgnet) == len(fgnet.targets)
         assert len(fgnet) == len(fgnet.data)
 
 
+@pytest.mark.no_gpu_ci
 def test_targets(fgnet_train):
     assert len(fgnet_train.targets) > 0
     assert isinstance(fgnet_train.targets, list)
@@ -124,6 +135,7 @@ def test_targets(fgnet_train):
     assert np.all(np.array(fgnet_train.targets) >= 0)
 
 
+@pytest.mark.no_gpu_ci
 def test_classes(fgnet_train, fgnet_test):
     assert len(fgnet_train.classes) == 6
     assert isinstance(fgnet_train.classes, list)

--- a/dlordinal/datasets/tests/test_hci.py
+++ b/dlordinal/datasets/tests/test_hci.py
@@ -32,11 +32,13 @@ def hci_test(base_path):
     return hci_test
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_basic(hci_train, hci_test):
     assert len(hci_train) > 0
     assert len(hci_test) > 0
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_categories(hci_train, hci_test):
     train_categories = set()
     for _, label in hci_train:
@@ -49,6 +51,7 @@ def test_hci_categories(hci_train, hci_test):
     assert test_categories == {0, 1, 2, 3, 4}
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_categories_count(hci_train, hci_test):
     train_category_counts = {0: 186, 1: 186, 2: 186, 3: 186, 4: 186}
     for _, label in hci_train:
@@ -61,6 +64,7 @@ def test_hci_categories_count(hci_train, hci_test):
     assert all(count > 0 for count in test_category_counts.values())
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_image_size(hci_train, hci_test):
     for img, _ in hci_train:
         assert img.shape == (3, 224, 224)
@@ -68,6 +72,7 @@ def test_hci_image_size(hci_train, hci_test):
         assert img.shape == (3, 224, 224)
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_md5_verification(base_path, tmp_path):
     dst = tmp_path / "hci"
     shutil.copytree(base_path, dst, dirs_exist_ok=True)
@@ -95,6 +100,7 @@ def test_hci_md5_verification(base_path, tmp_path):
     assert not mutable_hci_test._verify_md5sums()
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_prepare_after_corruption(base_path, tmp_path, hci_train, hci_test):
     dst = tmp_path / "hci"
     shutil.copytree(base_path, dst, dirs_exist_ok=True)
@@ -138,6 +144,7 @@ def test_hci_prepare_after_corruption(base_path, tmp_path, hci_train, hci_test):
     assert mutable_hci_test._verify_md5sums()
 
 
+@pytest.mark.no_gpu_ci
 def test_hci_load_data_with_dataloader(hci_train, hci_test):
     from torch.utils.data import DataLoader
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    no_gpu_ci: tests that should NOT run in GPU CI runners


### PR DESCRIPTION
This PR introduces a new `no_gpu_ci` pytest marker to control test execution in GPU CI environments.

### Changes
- Added the `no_gpu_ci` marker to `pytest.ini`
- Marked tests that do not benefit from GPU execution
- Updated test selection logic to allow skipping irrelevant tests in GPU runners

### Motivation
Some tests do not use GPU resources and do not provide additional value when executed on GPU runners. This marker allows us to exclude them from GPU CI jobs, reducing execution time and resource usage.

### Usage
GPU CI now runs:

```bash
pytest -m "not no_gpu_ci" -n auto
```