### PR TITLE
[MNT] Use GPU runner wrapper script to avoid OOM errors

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,6 +50,10 @@ jobs:
     env:
       PYTEST_CUDA_ONLY: "1"
 
+    defaults:
+      run:
+        shell: /usr/local/bin/gpu-run.sh {0}
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,10 +50,6 @@ jobs:
     env:
       PYTEST_CUDA_ONLY: "1"
 
-    defaults:
-      run:
-        shell: /usr/local/bin/gpu-run.sh {0}
-
     strategy:
       fail-fast: false
       matrix:
@@ -74,7 +70,7 @@ jobs:
         pip install .[dev]
 
     - name: Run tests
-      run: python -m pytest -n auto -m "not no_gpu_ci"
+      run: gpu-run.sh python -m pytest -n auto -m "not no_gpu_ci"
 
   tests-codecov:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR introduces a change in GPU tests workflow to run using the gpu shell wrapper that selects a free gpu automatically to avoid OOM errors.